### PR TITLE
DBサービスのヘルスチェックパラメータ修正

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -41,7 +41,9 @@ services:
       - 3306:3306
     healthcheck:
       test: "mysqladmin ping -h 127.0.0.1 -u root -p$$MYSQL_ROOT_PASSWORD"
-      interval: 5s
+      start_period: 10s
+      start_interval: 1s
+      interval: 60s
       timeout: 5s
       retries: 10
 
@@ -63,7 +65,9 @@ services:
       - 3307:3306
     healthcheck:
       test: "mysqladmin ping -h 127.0.0.1 -u root -p$$MYSQL_ROOT_PASSWORD"
-      interval: 5s
+      start_period: 10s
+      start_interval: 1s
+      interval: 60s
       timeout: 5s
       retries: 10
 


### PR DESCRIPTION
DBサービスをより早く起動させるためヘルスチェックパラメータを修正。
- 起動中は頻繁にチェック
- 起動後は負荷を減らすためチェック間隔を長くする
