### PR TITLE
ruff, mypy のターゲットディレクトリ修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Install python packages
         run: uv sync --all-extras
       - name: Check format
-        run: uv run ruff check src/
+        run: uv run ruff check ./
       - name: Check types
-        run: uv run mypy src
-      - name: Check openapi.json
+        run: uv run mypy .
+      - name: Check update openapi.json
         run: diff ./openapi.json <(uv run python -m src.generate_openapi)
   test:
     name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,13 @@ dev = [
 line-length = 100
 indent-width = 4
 target-version = "py313"
+exclude = [
+    ".venv",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "tests",
+]
 
 [tool.ruff.format]
 quote-style = "double"
@@ -41,11 +48,12 @@ split-on-trailing-comma = true
 
 [tool.mypy]
 python_version = "3.13"
+exclude = "^tests/"
 
 [tool.taskipy.tasks]
 test = "docker compose exec api pytest"
-format = "ruff format src/"
-check = "mypy src"
+format = "ruff format ./"
+check = "mypy ."
 buildapp = "docker compose build api"
 loginapp = "docker compose exec api bash"
 openapi = "python -m src.generate_openapi > openapi.json"


### PR DESCRIPTION
エディタ(vs code)上の`mypy`, `ruff` チェック で警告が出ないように以下の様に修正

- `ruff`, `mypy` のターゲットディレクトリを `src/` から `./` に変更
- 上記に伴う対象外の設定追加
