### PR TITLE
認証許可系APIテストの追加

### DIFF
--- a/tests/auth/test_login.py
+++ b/tests/auth/test_login.py
@@ -1,0 +1,92 @@
+from fastapi.testclient import TestClient
+
+from src.libs.enum import AuthorityEnum
+from tests.conftest import SessionForTest
+
+from ..base import BaseTest
+
+
+class TestLogin(BaseTest):
+    def test_login_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+    ):
+        """
+        正常系:
+        ログイン
+        """
+        # テスト用ユーザの作成
+        self.create_user(
+            db_session,
+            name="test_user",
+            password="test_password",
+            authority=AuthorityEnum.READWRITE,
+        )
+
+        # リクエストボディの作成
+        request_body = {
+            "username": "test_user",
+            "password": "test_password",
+        }
+
+        # リクエストの送信
+        response = client.post("/token", data=request_body)
+
+        # レスポンスの検証
+        assert response.status_code == 200
+        response_body = response.json()
+        assert "access_token" in response_body
+        assert "token_type" in response_body
+        assert response_body["token_type"] == "bearer"
+        assert len(response_body["access_token"]) > 0
+
+    def test_login_invalid_user(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+    ):
+        """
+        異常系:
+        存在しないユーザでログイン
+        """
+        # リクエストボディの作成
+        request_body = {
+            "username": "test_user",
+            "password": "test_password",
+        }
+
+        # リクエストの送信
+        response = client.post("/token", data=request_body)
+
+        # レスポンスの検証
+        assert response.status_code == 401
+
+    def test_login_invalid_password(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+    ):
+        """
+        異常系:
+        パスワード不一致
+        """
+        # テスト用ユーザの作成
+        self.create_user(
+            db_session,
+            name="test_user",
+            password="test_password",
+            authority=AuthorityEnum.READWRITE,
+        )
+
+        # リクエストボディの作成
+        request_body = {
+            "username": "test_user",
+            "password": "invalid_password",
+        }
+
+        # リクエストの送信
+        response = client.post("/token", data=request_body)
+
+        # レスポンスの検証
+        assert response.status_code == 401

--- a/tests/auth/test_me.py
+++ b/tests/auth/test_me.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+
+from src.libs.enum import AuthorityEnum
+from tests.conftest import SessionForTest
+
+from ..base import BaseTest
+
+
+class TestMe(BaseTest):
+    def test_get_login_user_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
+        """
+        正常系:
+        ログインユーザー取得
+        """
+        # リクエストの送信
+        response = client.get("/me")
+
+        # レスポンスの検証
+        assert response.status_code == 200
+        response_body = response.json()
+        assert response_body["name"] == "test_user"
+        assert response_body["authority"] == AuthorityEnum.ADMIN.value
+
+    def test_not_authenticated(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+    ):
+        """
+        異常系:
+        認証されていない
+        """
+        # リクエストの送信
+        response = client.get("/me")
+
+        # レスポンスの検証
+        print(response.json())
+        assert response.status_code == 401

--- a/tests/bookmark/test_add_bookmark.py
+++ b/tests/bookmark/test_add_bookmark.py
@@ -13,7 +13,12 @@ class TestAddBookmark(BaseTest):
     ブックマーク追加のテストクラス
     """
 
-    def test_add_normal(self, client: TestClient, db_session: SessionForTest):
+    def test_add_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         ブックマークを1つ追加
@@ -58,7 +63,12 @@ class TestAddBookmark(BaseTest):
             [bookmark.id]
         )
 
-    def test_add_duplicate(self, client: TestClient, db_session: SessionForTest):
+    def test_add_duplicate(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ブックマーク重複追加
@@ -76,7 +86,12 @@ class TestAddBookmark(BaseTest):
         response = client.post("/bookmarks", json=request_body)
         assert response.status_code == 409
 
-    def test_add_invalid_url(self, client: TestClient, db_session: SessionForTest):
+    def test_add_invalid_url(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ブックマークURL不正
@@ -110,7 +125,12 @@ class TestAddBookmark(BaseTest):
         response = client.post("/bookmarks", json=request_body)
         assert response.status_code == 422
 
-    def test_add_invalid_memo(self, client: TestClient, db_session: SessionForTest):
+    def test_add_invalid_memo(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ブックマークメモ不正
@@ -132,7 +152,12 @@ class TestAddBookmark(BaseTest):
         response = client.post("/bookmarks", json=request_body)
         assert response.status_code == 422
 
-    def test_add_invalid_tags(self, client: TestClient, db_session: SessionForTest):
+    def test_add_invalid_tags(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ブックマークタグ不正

--- a/tests/bookmark/test_delete_bookmark.py
+++ b/tests/bookmark/test_delete_bookmark.py
@@ -13,7 +13,12 @@ class TestDeleteBookmark(BaseTest):
     ブックマーク削除のテストクラス
     """
 
-    def test_delete_normal(self, client: TestClient, db_session: SessionForTest):
+    def test_delete_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         ブックマークを1つ削除
@@ -33,7 +38,12 @@ class TestDeleteBookmark(BaseTest):
         assert db_session.query(BookmarkTagDao).filter_by(bookmark_id=bookmark_id).count() == 0
         assert db_session.query(TagDao).count() == 2  # タグは削除されない
 
-    def test_delete_notfound(self, client: TestClient, db_session: SessionForTest):
+    def test_delete_notfound(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ハッシュIDが存在しないブックマークを削除
@@ -49,7 +59,12 @@ class TestDeleteBookmark(BaseTest):
         # レスポンスの検証
         assert response.status_code == 404
 
-    def test_add_invalid_hashed_id(self, client: TestClient, db_session: SessionForTest):
+    def test_add_invalid_hashed_id(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ハッシュID不正

--- a/tests/bookmark/test_get_bookmark.py
+++ b/tests/bookmark/test_get_bookmark.py
@@ -11,7 +11,12 @@ class TestGetBookmark(BaseTest):
     ブックマーク取得テストクラス
     """
 
-    def test_get_one_normal(self, client: TestClient, db_session: SessionForTest):
+    def test_get_one_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         ブックマークを1つ取得
@@ -36,7 +41,12 @@ class TestGetBookmark(BaseTest):
         assert res_bookmark["created_at"] == datetime_to_str(db_bookmark.created_at)
         assert res_bookmark["updated_at"] == datetime_to_str(db_bookmark.updated_at)
 
-    def test_get_list_normal(self, client: TestClient, db_session: SessionForTest):
+    def test_get_list_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         通常系:
         ブックマークリスト全件取得
@@ -64,7 +74,12 @@ class TestGetBookmark(BaseTest):
             assert res_bookmark["created_at"] == datetime_to_str(db_bookmark.created_at)
             assert res_bookmark["updated_at"] == datetime_to_str(db_bookmark.updated_at)
 
-    def test_get_list_by_tagname(self, client: TestClient, db_session: SessionForTest):
+    def test_get_list_by_tagname(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         通常系:
         タグ名でブックマークリスト取得
@@ -92,7 +107,12 @@ class TestGetBookmark(BaseTest):
         assert res_bookmark["created_at"] == datetime_to_str(db_bookmark.created_at)
         assert res_bookmark["updated_at"] == datetime_to_str(db_bookmark.updated_at)
 
-    def test_get_one_notfound(self, client: TestClient, db_session: SessionForTest):
+    def test_get_one_notfound(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ハッシュIDが存在しないブックマーク取得
@@ -108,7 +128,12 @@ class TestGetBookmark(BaseTest):
         # レスポンスの検証
         assert response.status_code == 404
 
-    def test_get_invalid_hashed_id(self, client: TestClient, db_session: SessionForTest):
+    def test_get_invalid_hashed_id(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ハッシュID不正
@@ -123,7 +148,12 @@ class TestGetBookmark(BaseTest):
         response = client.get(f"/bookmarks/{hashed_id}")
         assert response.status_code == 422
 
-    def test_get_list_by_tagname_notfound(self, client: TestClient, db_session: SessionForTest):
+    def test_get_list_by_tagname_notfound(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         存在しないタグ名でブックマークリスト取得
@@ -140,7 +170,12 @@ class TestGetBookmark(BaseTest):
         assert "bookmarks" in response_body
         assert len(response_body["bookmarks"]) == 0
 
-    def test_get_list_by_tagname_invalid(self, client: TestClient, db_session: SessionForTest):
+    def test_get_list_by_tagname_invalid(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         タグ名不正

--- a/tests/bookmark/test_update_bookmark.py
+++ b/tests/bookmark/test_update_bookmark.py
@@ -14,7 +14,12 @@ class TestUpdateBookmark(BaseTest):
     ブックマーク更新テストクラス
     """
 
-    def test_update_normal(self, client: TestClient, db_session: SessionForTest):
+    def test_update_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         ブックマークを1件更新
@@ -65,7 +70,12 @@ class TestUpdateBookmark(BaseTest):
             [updated_db_bookmark.id]
         )
 
-    def test_update_same_tags(self, client: TestClient, db_session: SessionForTest):
+    def test_update_same_tags(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         他のURLと同じタグ名に更新
@@ -90,7 +100,12 @@ class TestUpdateBookmark(BaseTest):
         assert updated_bookmark["created_at"] == datetime_to_str(bookmark1.created_at)
         assert updated_bookmark["updated_at"] is not None
 
-    def test_update_memo_only(self, client: TestClient, db_session: SessionForTest):
+    def test_update_memo_only(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         メモのみ更新
@@ -140,7 +155,12 @@ class TestUpdateBookmark(BaseTest):
             [updated_db_bookmark.id]
         )
 
-    def test_update_tags_only(self, client: TestClient, db_session: SessionForTest):
+    def test_update_tags_only(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         タグのみ更新
@@ -193,7 +213,12 @@ class TestUpdateBookmark(BaseTest):
             [updated_db_bookmark.id]
         )
 
-    def test_update_notfound(self, client: TestClient, db_session: SessionForTest):
+    def test_update_notfound(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """ "
         異常系:
         ハッシュIDが存在しないブックマークを更新
@@ -209,7 +234,12 @@ class TestUpdateBookmark(BaseTest):
         # レスポンスの検証
         assert response.status_code == 404
 
-    def test_update_invalid_hashed_id(self, client: TestClient, db_session: SessionForTest):
+    def test_update_invalid_hashed_id(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ハッシュID不正
@@ -226,7 +256,12 @@ class TestUpdateBookmark(BaseTest):
         response = client.patch(f"/bookmarks/{hashed_id}", json=request_body)
         assert response.status_code == 422
 
-    def test_update_invalid_tags(self, client: TestClient, db_session: SessionForTest):
+    def test_update_invalid_tags(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         タグ名指定不正
@@ -258,7 +293,12 @@ class TestUpdateBookmark(BaseTest):
         response = client.patch(f"/bookmarks/{bookmark.hashed_id}", json=request_body)
         assert response.status_code == 422
 
-    def test_update_invalid_memo(self, client: TestClient, db_session: SessionForTest):
+    def test_update_invalid_memo(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         メモ指定不正

--- a/tests/user/test_add_user.py
+++ b/tests/user/test_add_user.py
@@ -1,10 +1,8 @@
 from fastapi.testclient import TestClient
 
 from src.dao.models.user import UserDao
-from src.entities.user import UserEntity
 from src.libs.enum import AuthorityEnum
-from src.main import app
-from src.services.auth import AuthorizeService, get_current_active_user
+from src.services.auth import AuthorizeService
 from tests.conftest import SessionForTest
 
 from ..base import BaseTest
@@ -15,7 +13,12 @@ class TestAddUser(BaseTest):
     ユーザー追加のテストクラス
     """
 
-    def test_add_normal(self, client: TestClient, db_session: SessionForTest):
+    def test_add_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         ユーザーを1つ追加
@@ -44,7 +47,12 @@ class TestAddUser(BaseTest):
         assert user.disabled is False
         assert user.authority == request_body["authority"]
 
-    def test_add_duplicate(self, client: TestClient, db_session: SessionForTest):
+    def test_add_duplicate(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ユーザー重複追加
@@ -62,7 +70,12 @@ class TestAddUser(BaseTest):
         response = client.post("/users", json=request_body)
         assert response.status_code == 409
 
-    def test_add_invalid_name(self, client: TestClient, db_session: SessionForTest):
+    def test_add_invalid_name(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ユーザー名不正
@@ -102,7 +115,12 @@ class TestAddUser(BaseTest):
         response = client.post("/users", json=request_body)
         assert response.status_code == 422
 
-    def test_add_invalid_password(self, client: TestClient, db_session: SessionForTest):
+    def test_add_invalid_password(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         パスワード不正
@@ -133,7 +151,12 @@ class TestAddUser(BaseTest):
         response = client.post("/users", json=request_body)
         assert response.status_code == 422
 
-    def test_add_invalid_authority(self, client: TestClient, db_session: SessionForTest):
+    def test_add_invalid_authority(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         権限不正
@@ -155,24 +178,16 @@ class TestAddUser(BaseTest):
         response = client.post("/users", json=request_body)
         assert response.status_code == 422
 
-    def test_add_by_not_admin_user(self, client: TestClient, db_session: SessionForTest):
+    def test_add_by_not_admin_user(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_not_admin_user: None,
+    ):
         """
         異常系:
         権限がないユーザーがユーザー追加
         """
-
-        def get_current_active_user_for_not_admin_testing():
-            return UserEntity(
-                name="test_user",
-                hashed_password="****",
-                authority=AuthorityEnum.READWRITE,
-                disabled=False,
-            )
-
-        app.dependency_overrides[get_current_active_user] = (
-            get_current_active_user_for_not_admin_testing
-        )
-
         request_body = {
             "name": "test",
             "password": "password",

--- a/tests/user/test_get_user.py
+++ b/tests/user/test_get_user.py
@@ -15,7 +15,12 @@ class TestGetUser(BaseTest):
     ユーザー取得テストクラス
     """
 
-    def test_get_one_normal(self, client: TestClient, db_session: SessionForTest):
+    def test_get_one_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         ユーザーを1つ取得
@@ -34,7 +39,12 @@ class TestGetUser(BaseTest):
         assert res_user["disabled"] == db_user.disabled
         assert res_user["authority"] == db_user.authority
 
-    def test_get_list_normal(self, client: TestClient, db_session: SessionForTest):
+    def test_get_list_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         通常系:
         ユーザーリスト全件取得
@@ -60,7 +70,12 @@ class TestGetUser(BaseTest):
             assert res_user["disabled"] == db_user.disabled
             assert res_user["authority"] == db_user.authority
 
-    def test_get_one_notfound(self, client: TestClient, db_session: SessionForTest):
+    def test_get_one_notfound(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ユーザー名が存在しないユーザー取得
@@ -74,7 +89,12 @@ class TestGetUser(BaseTest):
         # レスポンスの検証
         assert response.status_code == 404
 
-    def test_get_invalid_name(self, client: TestClient, db_session: SessionForTest):
+    def test_get_invalid_name(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ユーザー名不正
@@ -89,7 +109,12 @@ class TestGetUser(BaseTest):
         response = client.get(f"/users/{name}")
         assert response.status_code == 422
 
-    def test_get_one_by_not_admin_user(self, client: TestClient, db_session: SessionForTest):
+    def test_get_one_by_not_admin_user(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         権限がないユーザーがユーザー情報を1つ取得
@@ -115,24 +140,16 @@ class TestGetUser(BaseTest):
         # レスポンスの検証
         assert response.status_code == 403
 
-    def test_get_list_by_not_admin_user(self, client: TestClient, db_session: SessionForTest):
+    def test_get_list_by_not_admin_user(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_not_admin_user: None,
+    ):
         """
         異常系:
         権限がないユーザーがユーザー情報リストを取得
         """
-
-        def get_current_active_user_for_not_admin_testing():
-            return UserEntity(
-                name="test_user",
-                hashed_password="****",
-                authority=AuthorityEnum.READWRITE,
-                disabled=False,
-            )
-
-        app.dependency_overrides[get_current_active_user] = (
-            get_current_active_user_for_not_admin_testing
-        )
-
         self.create_user(db_session, "test")
 
         # リクエストの送信

--- a/tests/user/test_update_user.py
+++ b/tests/user/test_update_user.py
@@ -1,10 +1,8 @@
 from fastapi.testclient import TestClient
 
 from src.dao.models.user import UserDao
-from src.entities.user import UserEntity
 from src.libs.enum import AuthorityEnum
-from src.main import app
-from src.services.auth import AuthorizeService, get_current_active_user
+from src.services.auth import AuthorizeService
 from tests.conftest import SessionForTest
 
 from ..base import BaseTest
@@ -15,7 +13,12 @@ class TestUpdateUser(BaseTest):
     ブックマーク更新テストクラス
     """
 
-    def test_update_normal(self, client: TestClient, db_session: SessionForTest):
+    def test_update_normal(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         ブックマークを1件更新
@@ -44,7 +47,12 @@ class TestUpdateUser(BaseTest):
         assert updated_user["disabled"] == updated_db_user.disabled
         assert updated_user["authority"] == updated_db_user.authority
 
-    def test_update_name_only(self, client: TestClient, db_session: SessionForTest):
+    def test_update_name_only(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         ユーザー名のみ更新
@@ -65,7 +73,12 @@ class TestUpdateUser(BaseTest):
         assert updated_user["disabled"] == updated_db_user.disabled
         assert updated_user["authority"] == updated_db_user.authority
 
-    def test_update_password_only(self, client: TestClient, db_session: SessionForTest):
+    def test_update_password_only(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         パスワードのみ更新
@@ -89,7 +102,12 @@ class TestUpdateUser(BaseTest):
         assert updated_user["disabled"] == updated_db_user.disabled
         assert updated_user["authority"] == updated_db_user.authority
 
-    def test_update_disabled_only(self, client: TestClient, db_session: SessionForTest):
+    def test_update_disabled_only(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         無効フラグのみ更新
@@ -110,7 +128,12 @@ class TestUpdateUser(BaseTest):
         assert updated_user["disabled"] == updated_db_user.disabled
         assert updated_user["authority"] == updated_db_user.authority
 
-    def test_update_authority_only(self, client: TestClient, db_session: SessionForTest):
+    def test_update_authority_only(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         正常系:
         権限のみ更新
@@ -131,7 +154,12 @@ class TestUpdateUser(BaseTest):
         assert updated_user["disabled"] == updated_db_user.disabled
         assert updated_user["authority"] == updated_db_user.authority
 
-    def test_update_notfound(self, client: TestClient, db_session: SessionForTest):
+    def test_update_notfound(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ユーザー名が存在しないユーザー更新
@@ -152,7 +180,12 @@ class TestUpdateUser(BaseTest):
         # レスポンスの検証
         assert response.status_code == 404
 
-    def test_update_invalid_name(self, client: TestClient, db_session: SessionForTest):
+    def test_update_invalid_name(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ユーザー名不正
@@ -180,7 +213,12 @@ class TestUpdateUser(BaseTest):
         response = client.patch("/users/test", json=request_body)
         assert response.status_code == 422
 
-    def test_update_invalid_password(self, client: TestClient, db_session: SessionForTest):
+    def test_update_invalid_password(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         パスワード不正
@@ -201,7 +239,12 @@ class TestUpdateUser(BaseTest):
         response = client.patch("/users/test", json=request_body)
         assert response.status_code == 422
 
-    def test_update_invalid_disabled(self, client: TestClient, db_session: SessionForTest):
+    def test_update_invalid_disabled(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         無効フラグ不正
@@ -215,7 +258,12 @@ class TestUpdateUser(BaseTest):
         response = client.patch("/users/test", json=request_body)
         assert response.status_code == 422
 
-    def test_update_invalid_authority(self, client: TestClient, db_session: SessionForTest):
+    def test_update_invalid_authority(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         権限不正
@@ -229,7 +277,12 @@ class TestUpdateUser(BaseTest):
         response = client.patch("/users/test", json=request_body)
         assert response.status_code == 422
 
-    def test_update_own_attribute(self, client: TestClient, db_session: SessionForTest):
+    def test_update_own_attribute(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_user: None,
+    ):
         """
         異常系:
         ログインユーザ自身の属性を更新
@@ -264,24 +317,16 @@ class TestUpdateUser(BaseTest):
         response = client.patch("/users/test_user", json=request_body)
         assert response.status_code == 400
 
-    def test_update_by_not_admin_user(self, client: TestClient, db_session: SessionForTest):
+    def test_update_by_not_admin_user(
+        self,
+        client: TestClient,
+        db_session: SessionForTest,
+        mock_get_current_active_not_admin_user: None,
+    ):
         """
         異常系:
         権限がないユーザーが他のユーザーを更新
         """
-
-        def get_current_active_user_for_not_admin_testing():
-            return UserEntity(
-                name="test_user",
-                hashed_password="****",
-                authority=AuthorityEnum.READWRITE,
-                disabled=False,
-            )
-
-        app.dependency_overrides[get_current_active_user] = (
-            get_current_active_user_for_not_admin_testing
-        )
-
         self.create_user(db_session, "test")
 
         # リクエストボディの作成


### PR DESCRIPTION
- 認証許可系API(`/token`, `/me`)テストの追加
- テストで使用しているモック処理を分離
