### PR TITLE
uvパッケージマネージャのインストール方法を修正

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,21 +1,21 @@
 ## Dockerfile for local
 
-ARG PYTHON_VERSION=3.13.7
+ARG PYTHON_VER=3.13
 
-## ----- Stage for building python packages base
-FROM python:${PYTHON_VERSION}-slim AS builder
-
-# uv(Pythonパッケージマネージャ)インストール
-RUN pip3 install uv
-ENV UV_PROJECT_ENVIRONMENT="/usr/local/"
+## ----- Stage for building python packages
+FROM ghcr.io/astral-sh/uv:python${PYTHON_VER}-trixie-slim AS builder
+WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen
 
-# Pythonモジュールのインストール
-COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen
+## ----- Stage for web app
+FROM python:${PYTHON_VER}-slim AS app
 
-## ----- Stage for web app base
-FROM python:${PYTHON_VERSION}-slim AS app
+ARG PYTHON_VER
 
 # ポート指定
 EXPOSE 8000
@@ -42,8 +42,7 @@ RUN apt-get update &&\
     rm -rf /var/lib/apt/lists/*
 
 # ビルド済みのpythonモジュールをコピー
-COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /app/.venv/lib/python${PYTHON_VER}/site-packages /usr/local/lib/python${PYTHON_VER}/site-packages
 
 # 実行ユーザ指定
 USER ${USER}
@@ -53,4 +52,4 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
 # デフォルトの起動コマンド設定
-CMD ["uvicorn", "src.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "-m", "uvicorn", "src.main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ python_version = "3.13"
 exclude = "^tests/"
 
 [tool.taskipy.tasks]
-test = "docker compose exec api pytest"
+test = "docker compose exec api python -m pytest"
 format = "ruff format ./"
 check = "mypy . ; bandit --quiet --recursive src"
 buildapp = "docker compose build api"


### PR DESCRIPTION
[ここ](https://nikkie-ftnext.hatenablog.com/entry/proposal-python-uv-application-minimum-docker-image-example-fastapi-202507)を参考にuvパッケージマネージャのインストール方法を修正