### PR TITLE
refactor: Tokenをauthorizeからdto/authに移動し循環importを解消

### DIFF
--- a/src/dto/auth.py
+++ b/src/dto/auth.py
@@ -9,7 +9,32 @@ from ..libs.constraints import (
     FIELD_STRING_USERNAME,
 )
 from ..libs.enum import AuthorityEnum
-from ..services.authorize import Token
+
+
+class Token(BaseModel):
+    """
+    アクセストークン
+    """
+
+    access_token: str
+    "アクセストークン"
+    refresh_token: str
+    "リフレッシュトークン"
+    token_type: str
+    "トークンの種類"
+
+    model_config = ConfigDict(
+        frozen=True,
+        json_schema_extra={
+            "examples": [
+                {
+                    "access_token": "XXXXXXXXXXXXXXX.XXXXXXXXXXXXXXXXXXXXX.XXXXXXXXXXXXXXXX",
+                    "refresh_token": "YYYYYYYYYYYYYYY.YYYYYYYYYYYYYYYYY.YYYYYYYYYYYYYYYYYYYY",
+                    "token_type": "bearer",
+                }
+            ]
+        },
+    )
 
 
 ## ログイン入力バリデーション

--- a/src/services/authorize.py
+++ b/src/services/authorize.py
@@ -13,36 +13,11 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 from sqlalchemy.orm.session import Session
 
 from ..dao.session import SessionDepend
+from ..dto.auth import RequestForLogin, Token
 from ..entities.user import UserEntity
 from ..repositories.user import UserRepository
 from .base import ServiceBase, ServiceError
 from .token_blacklist import TokenBlacklistService
-
-
-class Token(BaseModel):
-    """
-    アクセストークン
-    """
-
-    access_token: str
-    "アクセストークン"
-    refresh_token: str
-    "リフレッシュトークン"
-    token_type: str
-    "トークンの種類"
-
-    model_config = ConfigDict(
-        frozen=True,
-        json_schema_extra={
-            "examples": [
-                {
-                    "access_token": "XXXXXXXXXXXXXXX.XXXXXXXXXXXXXXXXXXXXX.XXXXXXXXXXXXXXXX",
-                    "refresh_token": "YYYYYYYYYYYYYYY.YYYYYYYYYYYYYYYYY.YYYYYYYYYYYYYYYYYYYY",
-                    "token_type": "bearer",
-                }
-            ]
-        },
-    )
 
 
 class TokenData(BaseModel):
@@ -238,8 +213,6 @@ class AuthorizeService(ServiceBase):
         Returns:
             作成されたアクセストークン
         """
-        from ..dto.auth import RequestForLogin
-
         try:
             RequestForLogin(username=form_data.username, password=form_data.password)
         except ValidationError:


### PR DESCRIPTION
## 変更内容

- `Token` クラスを `src/services/authorize.py` から `src/dto/auth.py` に移動
- `authorize.py` の遅延 import (`from ..dto.auth import RequestForLogin`) をモジュールレベルの import に変更
- `dto/auth.py` → `services/authorize.py` の循環参照を解消
