### PR TITLE
feat: repository層にクエリキャッシュを導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
         run: uv run pytest
         env:
           TEST_DB_HOST: localhost
-          REDIS_URL: redis://localhost:6379/0
+          BLACKLIST_REDIS_URL: redis://localhost:6379/0

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,9 +13,9 @@ services:
       DATABASE_PASSWORD: root
       DATABASE_NAME: app
       DATABASE_DEBUG: 1
-      REDIS_URL: redis://redis:6379/0
-      REDIS_FAIL_OPEN: 1
-      REDIS_BLACKLIST_DEFAULT_TTL_DAYS: 14
+      BLACKLIST_REDIS_URL: redis://redis:6379/0
+      BLACKLIST_REDIS_FAIL_OPEN: 1
+      BLACKLIST_REDIS_DEFAULT_TTL_DAYS: 14
     tty: true
     volumes:
       - ./:/opt/app

--- a/src/libs/cache/__init__.py
+++ b/src/libs/cache/__init__.py
@@ -1,8 +1,10 @@
 from .backends import ZstdMemoryBackend, ZstdRedisBackend
 from .decorator import query_cache
+from .provider import get_query_cache_region
 from .region import NullCacheRegion, create_memory_region, create_redis_region
 
 __all__ = [
+    "get_query_cache_region",
     "query_cache",
     "create_memory_region",
     "create_redis_region",

--- a/src/libs/cache/provider.py
+++ b/src/libs/cache/provider.py
@@ -1,0 +1,49 @@
+from functools import lru_cache
+from typing import Any
+from urllib.parse import urlsplit
+
+from dogpile.cache.region import CacheRegion
+
+from ..config import Config, get_config
+from ..log import get_logger
+from .region import NullCacheRegion, create_redis_region
+
+_logger = get_logger()
+
+
+def _build_connection_kwargs(config: Config) -> dict[str, Any]:
+    connection_kwargs: dict[str, Any] = {}
+    if urlsplit(config.cache_redis_url).scheme != "rediss":
+        return connection_kwargs
+
+    # blacklist 用 Redis 設定と分離した cache 用 SSL 設定だけをここで組み立てる。
+    connection_kwargs["ssl_cert_reqs"] = (
+        "required" if config.cache_redis_ssl_verify_cert else "none"
+    )
+    if config.cache_redis_ssl_ca_certs:
+        connection_kwargs["ssl_ca_certs"] = config.cache_redis_ssl_ca_certs
+    if config.cache_redis_ssl_certfile:
+        connection_kwargs["ssl_certfile"] = config.cache_redis_ssl_certfile
+    if config.cache_redis_ssl_keyfile:
+        connection_kwargs["ssl_keyfile"] = config.cache_redis_ssl_keyfile
+    return connection_kwargs
+
+
+@lru_cache
+def get_query_cache_region() -> CacheRegion | NullCacheRegion:
+    config = get_config()
+    if not config.cache_enabled:
+        return NullCacheRegion()
+
+    if not config.cache_redis_url:
+        _logger.warning("Query cache is enabled but CACHE_REDIS_URL is not configured")
+        return NullCacheRegion()
+
+    # Region はプロセス内で共有し、repository ごとに同じ backend を使い回す。
+    connection_kwargs = _build_connection_kwargs(config)
+    return create_redis_region(
+        url=config.cache_redis_url,
+        expiration_time=config.cache_redis_expiration_time,
+        zstd_level=config.cache_zstd_level,
+        connection_kwargs=connection_kwargs or None,
+    )

--- a/src/libs/cache/region.py
+++ b/src/libs/cache/region.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, TypeVar
 
 from dogpile.cache import make_region
@@ -44,36 +44,47 @@ def create_memory_region(expiration_time: int = 300, zstd_level: int = 3) -> Cac
 
 
 def create_redis_region(
+    url: str | None = None,
     host: str = "localhost",
     port: int = 6379,
     db: int = 0,
     expiration_time: int = 3600,
     zstd_level: int = 3,
+    connection_kwargs: Mapping[str, Any] | None = None,
 ) -> CacheRegion:
     """
     zstd 圧縮対応の Redis キャッシュリージョンを生成する。
 
     Args:
+        url: Redis 接続URL
         host: Redis ホスト
         port: Redis ポート
         db: Redis DB 番号
         expiration_time: キャッシュ有効期限
         zstd_level: zstd 圧縮レベル
+        connection_kwargs: Redis クライアント生成時の追加引数
 
     Returns:
         生成したキャッシュリージョン
     """
     _register_backends()
+    arguments: dict[str, Any] = {
+        "expiration_time": expiration_time,
+        "zstd_level": zstd_level,
+    }
+    if url is not None:
+        arguments["url"] = url
+    else:
+        arguments["host"] = host
+        arguments["port"] = port
+        arguments["db"] = db
+    if connection_kwargs is not None:
+        arguments["connection_kwargs"] = dict(connection_kwargs)
+
     return make_region().configure(
         _REDIS_BACKEND_NAME,
         expiration_time=expiration_time,
-        arguments={
-            "host": host,
-            "port": port,
-            "db": db,
-            "expiration_time": expiration_time,
-            "zstd_level": zstd_level,
-        },
+        arguments=arguments,
     )
 
 

--- a/src/libs/config.py
+++ b/src/libs/config.py
@@ -36,19 +36,35 @@ class Config(BaseModel):
     "リフレッシュトークンの有効期限(日)"
     access_token_expire_minutes: int
     "アクセストークンの有効期限(分)"
-    redis_url: str
-    "Redis接続URL"
-    redis_ssl_verify_cert: bool
-    "rediss:// 使用時にSSL証明書を検証するか"
-    redis_ssl_ca_certs: str
-    "CA証明書ファイルパス"
-    redis_ssl_certfile: str
-    "クライアント証明書ファイルパス (mTLS用)"
-    redis_ssl_keyfile: str
-    "クライアント秘密鍵ファイルパス (mTLS用)"
-    redis_fail_open: bool
-    "Redis障害時のフェイルオープン設定"
-    redis_blacklist_default_ttl_days: int
+    cache_enabled: bool
+    "クエリキャッシュ全体の有効/無効"
+    cache_redis_url: str
+    "クエリキャッシュ用 Redis 接続URL"
+    cache_redis_expiration_time: int
+    "クエリキャッシュのデフォルトTTL(秒)"
+    cache_zstd_level: int
+    "クエリキャッシュの zstd 圧縮レベル"
+    cache_redis_ssl_verify_cert: bool
+    "クエリキャッシュ用 rediss:// 使用時にSSL証明書を検証するか"
+    cache_redis_ssl_ca_certs: str
+    "クエリキャッシュ用 CA証明書ファイルパス"
+    cache_redis_ssl_certfile: str
+    "クエリキャッシュ用クライアント証明書ファイルパス (mTLS用)"
+    cache_redis_ssl_keyfile: str
+    "クエリキャッシュ用クライアント秘密鍵ファイルパス (mTLS用)"
+    blacklist_redis_url: str
+    "ブラックリスト用 Redis 接続URL"
+    blacklist_redis_ssl_verify_cert: bool
+    "ブラックリスト用 rediss:// 使用時にSSL証明書を検証するか"
+    blacklist_redis_ssl_ca_certs: str
+    "ブラックリスト用 CA証明書ファイルパス"
+    blacklist_redis_ssl_certfile: str
+    "ブラックリスト用クライアント証明書ファイルパス (mTLS用)"
+    blacklist_redis_ssl_keyfile: str
+    "ブラックリスト用クライアント秘密鍵ファイルパス (mTLS用)"
+    blacklist_redis_fail_open: bool
+    "ブラックリスト用 Redis 障害時のフェイルオープン設定"
+    blacklist_redis_default_ttl_days: int
     "ブラックリストのデフォルトTTL(日)"
 
     model_config = ConfigDict(frozen=True)
@@ -59,7 +75,7 @@ load_dotenv()
 env = os.environ
 
 _refresh_days = int(env.get("REFRESH_TOKEN_EXPIRE_DAYS", 14))
-_blacklist_default_ttl_days = int(env.get("REDIS_BLACKLIST_DEFAULT_TTL_DAYS", _refresh_days))
+_blacklist_default_ttl_days = int(env.get("BLACKLIST_REDIS_DEFAULT_TTL_DAYS", _refresh_days))
 
 _config = Config(
     database_host=env.get("DATABASE_HOST", "localhost"),
@@ -74,13 +90,21 @@ _config = Config(
     hash_salt=env.get("SALT", "__SALTSALTSALT__"),
     refresh_token_expire_days=_refresh_days,
     access_token_expire_minutes=int(env.get("ACCESS_TOKEN_EXPIRE_MINUTES", 20)),
-    redis_url=env.get("REDIS_URL", ""),
-    redis_ssl_verify_cert=bool(int(env.get("REDIS_SSL_VERIFY_CERT", 0))),
-    redis_ssl_ca_certs=env.get("REDIS_SSL_CA_CERTS", ""),
-    redis_ssl_certfile=env.get("REDIS_SSL_CERTFILE", ""),
-    redis_ssl_keyfile=env.get("REDIS_SSL_KEYFILE", ""),
-    redis_fail_open=bool(int(env.get("REDIS_FAIL_OPEN", 1))),
-    redis_blacklist_default_ttl_days=_blacklist_default_ttl_days,
+    cache_enabled=bool(int(env.get("CACHE_ENABLED", 0))),
+    cache_redis_url=env.get("CACHE_REDIS_URL", ""),
+    cache_redis_expiration_time=int(env.get("CACHE_REDIS_EXPIRATION_TIME", 300)),
+    cache_zstd_level=int(env.get("CACHE_ZSTD_LEVEL", 3)),
+    cache_redis_ssl_verify_cert=bool(int(env.get("CACHE_REDIS_SSL_VERIFY_CERT", 0))),
+    cache_redis_ssl_ca_certs=env.get("CACHE_REDIS_SSL_CA_CERTS", ""),
+    cache_redis_ssl_certfile=env.get("CACHE_REDIS_SSL_CERTFILE", ""),
+    cache_redis_ssl_keyfile=env.get("CACHE_REDIS_SSL_KEYFILE", ""),
+    blacklist_redis_url=env.get("BLACKLIST_REDIS_URL", ""),
+    blacklist_redis_ssl_verify_cert=bool(int(env.get("BLACKLIST_REDIS_SSL_VERIFY_CERT", 0))),
+    blacklist_redis_ssl_ca_certs=env.get("BLACKLIST_REDIS_SSL_CA_CERTS", ""),
+    blacklist_redis_ssl_certfile=env.get("BLACKLIST_REDIS_SSL_CERTFILE", ""),
+    blacklist_redis_ssl_keyfile=env.get("BLACKLIST_REDIS_SSL_KEYFILE", ""),
+    blacklist_redis_fail_open=bool(int(env.get("BLACKLIST_REDIS_FAIL_OPEN", 1))),
+    blacklist_redis_default_ttl_days=_blacklist_default_ttl_days,
 )
 
 

--- a/src/libs/redis_client.py
+++ b/src/libs/redis_client.py
@@ -8,10 +8,10 @@ from .log import get_logger
 
 _config = get_config()
 _logger = get_logger()
-_redis_client: Redis | None = None
+_blacklist_redis_client: Redis | None = None
 
 
-def _merge_redis_url_query(redis_url: str) -> str:
+def _merge_blacklist_redis_url_query(redis_url: str) -> str:
     parts = urlsplit(redis_url)
     query_params = parse_qsl(parts.query, keep_blank_values=True)
     existing_keys = {key for key, _ in query_params}
@@ -20,35 +20,35 @@ def _merge_redis_url_query(redis_url: str) -> str:
         query_params.append(("decode_responses", "True"))
     if parts.scheme == "rediss":
         if "ssl_cert_reqs" not in existing_keys:
-            ssl_cert_reqs = "required" if _config.redis_ssl_verify_cert else "none"
+            ssl_cert_reqs = "required" if _config.blacklist_redis_ssl_verify_cert else "none"
             query_params.append(("ssl_cert_reqs", ssl_cert_reqs))
-        if _config.redis_ssl_ca_certs and "ssl_ca_certs" not in existing_keys:
-            query_params.append(("ssl_ca_certs", _config.redis_ssl_ca_certs))
-        if _config.redis_ssl_certfile and "ssl_certfile" not in existing_keys:
-            query_params.append(("ssl_certfile", _config.redis_ssl_certfile))
-        if _config.redis_ssl_keyfile and "ssl_keyfile" not in existing_keys:
-            query_params.append(("ssl_keyfile", _config.redis_ssl_keyfile))
+        if _config.blacklist_redis_ssl_ca_certs and "ssl_ca_certs" not in existing_keys:
+            query_params.append(("ssl_ca_certs", _config.blacklist_redis_ssl_ca_certs))
+        if _config.blacklist_redis_ssl_certfile and "ssl_certfile" not in existing_keys:
+            query_params.append(("ssl_certfile", _config.blacklist_redis_ssl_certfile))
+        if _config.blacklist_redis_ssl_keyfile and "ssl_keyfile" not in existing_keys:
+            query_params.append(("ssl_keyfile", _config.blacklist_redis_ssl_keyfile))
 
     new_query = urlencode(query_params, doseq=True)
     return urlunsplit((parts.scheme, parts.netloc, parts.path, new_query, parts.fragment))
 
 
-def get_redis_client() -> Redis | None:
+def get_blacklist_redis_client() -> Redis | None:
     """
-    Redisクライアントを取得する
+    ブラックリスト用Redisクライアントを取得する
 
     Returns:
         Redisクライアント(未設定時はNone)
     """
-    global _redis_client
-    if not _config.redis_url:
-        _logger.warning("Redis URL is not configured")
+    global _blacklist_redis_client
+    if not _config.blacklist_redis_url:
+        _logger.warning("Blacklist Redis URL is not configured")
         return None
-    if _redis_client is None:
+    if _blacklist_redis_client is None:
         try:
-            redis_url = _merge_redis_url_query(_config.redis_url)
-            _redis_client = Redis.from_url(redis_url)
+            redis_url = _merge_blacklist_redis_url_query(_config.blacklist_redis_url)
+            _blacklist_redis_client = Redis.from_url(redis_url)
         except RedisError as exc:
-            _logger.warning("Redis connection failed: %s", exc)
+            _logger.warning("Blacklist Redis connection failed: %s", exc)
             return None
-    return _redis_client
+    return _blacklist_redis_client

--- a/src/repositories/base.py
+++ b/src/repositories/base.py
@@ -1,5 +1,9 @@
+from uuid import uuid4
+
+from dogpile.cache.region import CacheRegion
 from sqlalchemy.orm.session import Session
 
+from ..libs.cache import NullCacheRegion, get_query_cache_region
 from ..libs.page import Page
 
 
@@ -31,6 +35,7 @@ class BaseRepository:
         self,
         session: Session,
         page: Page | None = None,
+        region: CacheRegion | NullCacheRegion | None = None,
     ) -> None:
         """
         初期化処理
@@ -43,3 +48,77 @@ class BaseRepository:
         "セッション"
         self.page = page
         "ページ情報"
+        self.region = region if region is not None else get_query_cache_region()
+        "クエリキャッシュリージョン"
+
+    def _page_cache_fragment(self) -> str:
+        """
+        現在のページ条件をキャッシュキー向けの文字列に変換する。
+
+        Returns:
+            ページ条件を表す文字列
+        """
+        if self.page is None:
+            return "page:none:size:none"
+        return f"page:{self.page.number}:size:{self.page.size}"
+
+    def _cache_version_key(self, namespace: str) -> str:
+        """
+        指定 namespace のキャッシュバージョン管理キーを返す。
+
+        Args:
+            namespace: キャッシュの論理グループ名
+
+        Returns:
+            バージョン管理キー
+        """
+        return f"{self.__class__.__module__}.{self.__class__.__qualname__}:version:{namespace}"
+
+    def _get_cache_version(self, namespace: str) -> str:
+        """
+        指定 namespace の現在バージョンを取得する。
+
+        Args:
+            namespace: キャッシュの論理グループ名
+
+        Returns:
+            現在のバージョン文字列
+        """
+        version_key = self._cache_version_key(namespace)
+        # 初回生成も複数リクエストで競合し得るため、get+set ではなく region 側の排他に寄せる。
+        version = self.region.get_or_create(version_key, self._new_cache_version)
+        return str(version)
+
+    def _bump_cache_versions(self, *namespaces: str) -> None:
+        """
+        指定 namespace 群のキャッシュバージョンを進める。
+
+        Args:
+            namespaces: 更新対象の namespace 一覧
+        """
+        for namespace in namespaces:
+            # 競合で無効化を取りこぼさないよう、read-modify-write ではなく毎回新しい一意値に差し替える。
+            self.region.set(
+                self._cache_version_key(namespace),
+                self._new_cache_version(),
+            )
+
+    def _delete_cache_keys(self, *keys: str) -> None:
+        """
+        指定されたキャッシュキー群を削除する。
+
+        Args:
+            keys: 削除対象のキャッシュキー一覧
+        """
+        for key in keys:
+            self.region.delete(key)
+
+    @staticmethod
+    def _new_cache_version() -> str:
+        """
+        キャッシュバージョン用の一意なトークンを生成する。
+
+        Returns:
+            新しいバージョン文字列
+        """
+        return uuid4().hex

--- a/src/repositories/bookmark.py
+++ b/src/repositories/bookmark.py
@@ -1,8 +1,11 @@
+from urllib.parse import quote
+
 from ..dao.models.bookmark import BookmarkDao
 from ..dao.operators.bookmark import BookmarkDaoOperator
 from ..dao.operators.bookmark_tag import BookmarkTagDaoOperator
 from ..dao.operators.tag import TagDaoOperator
 from ..entities.bookmark import BookmarkEntity
+from ..libs.cache import query_cache
 from .base import BaseRepository
 
 
@@ -16,8 +19,8 @@ class BookmarkRepository(BaseRepository):
         self.bookmark_operator = BookmarkDaoOperator(self.session, page=self.page)
         self.tag_operator = TagDaoOperator(self.session)
         self.bookmark_tag_operator = BookmarkTagDaoOperator(self.session)
-        self.loaded_bookmark_dao: BookmarkDao | None = None
 
+    @query_cache(key_func=lambda self, hashed_id: type(self)._find_one_cache_key(hashed_id))
     def find_one(self, /, hashed_id: str) -> BookmarkEntity:
         """
         指定されたハッシュIDに対応するブックマークを1件取得する。
@@ -35,8 +38,6 @@ class BookmarkRepository(BaseRepository):
         if not bookmark_dao:
             raise self.NotFoundError("Not found specified data.")
 
-        self.loaded_bookmark_dao = bookmark_dao
-
         # ループしない前提なのでn+1にはならない
         tags = self.tag_operator.find_by_bookmark_id(bookmark_dao.id)
 
@@ -45,6 +46,7 @@ class BookmarkRepository(BaseRepository):
 
         return BookmarkEntity(**params)
 
+    @query_cache(key_func=lambda self: self._find_all_cache_key())
     def find_all(self) -> list[BookmarkEntity]:
         """
         全てのブックマークを取得する。
@@ -55,6 +57,7 @@ class BookmarkRepository(BaseRepository):
         bookmark_daos = self.bookmark_operator.find_all()
         return self._create_entities_with_tags(bookmark_daos)
 
+    @query_cache(key_func=lambda self, tag_names: self._find_by_tags_cache_key(tag_names))
     def find_by_tags(self, tag_names: list[str]) -> list[BookmarkEntity]:
         """
         指定されたタグ名に関連付けられたブックマークを取得する。
@@ -107,28 +110,35 @@ class BookmarkRepository(BaseRepository):
 
         self.bookmark_operator.save(bookmark_dao)
         self._save_tags(bookmark.tags, bookmark_dao.id)
+        # 詳細キーは直接削除し、一覧系は version を進めてまとめて無効化する。
+        self._delete_cache_keys(type(self)._find_one_cache_key(bookmark_dao.hashed_id))
+        self._bump_cache_versions("list", "tag-list")
 
-    def update_one(self, bookmark: BookmarkEntity) -> None:
+    def update_one(self, bookmark: BookmarkEntity, /, current_hashed_id: str) -> None:
         """
         既存のブックマークを更新する。
 
-        事前に `find_one()` を使用して更新対象のブックマークを取得しておく必要がある。
-
         Args:
             bookmark: 更新するブックマークエンティティ
+            current_hashed_id: 更新対象の現在のハッシュID
 
         Raises:
-            Error: 更新対象のブックマークを取得(`find_one()`)していない
+            NotFoundError: 更新対象のブックマークが存在しない
         """
-        if self.loaded_bookmark_dao is None:
-            raise self.Error("Not loaded bookmark")
-
-        bookmark_dao = self.loaded_bookmark_dao
+        bookmark_dao = self.bookmark_operator.find_one_by_hashed_id(current_hashed_id)
+        if bookmark_dao is None:
+            raise self.NotFoundError("Not found specified data.")
         for k, v in bookmark.model_dump(exclude_none=True, exclude={"tags"}).items():
             setattr(bookmark_dao, k, v)
 
         self.bookmark_operator.save(bookmark_dao)
         self._save_tags(bookmark.tags, bookmark_dao.id)
+        # ハッシュID変更にも耐えられるよう、旧キーと新キーの両方を削除する。
+        self._delete_cache_keys(
+            type(self)._find_one_cache_key(current_hashed_id),
+            type(self)._find_one_cache_key(bookmark_dao.hashed_id),
+        )
+        self._bump_cache_versions("list", "tag-list")
 
     def _save_tags(self, tags: list[str] | None, bookmark_dao_id: int) -> None:
         """
@@ -161,3 +171,19 @@ class BookmarkRepository(BaseRepository):
             raise self.NotFoundError("Not found specified data.")
 
         self.bookmark_operator.delete(bookmark_dao)
+        self._delete_cache_keys(type(self)._find_one_cache_key(hashed_id))
+        self._bump_cache_versions("list", "tag-list")
+
+    @staticmethod
+    def _find_one_cache_key(hashed_id: str | None) -> str:
+        return f"bookmark:detail:{hashed_id}"
+
+    def _find_all_cache_key(self) -> str:
+        version = self._get_cache_version("list")
+        return f"bookmark:list:all:v:{version}:{self._page_cache_fragment()}"
+
+    def _find_by_tags_cache_key(self, tag_names: list[str]) -> str:
+        version = self._get_cache_version("tag-list")
+        # 各タグ名をエスケープして連結し、区切り文字を含むタグでもキー衝突しないようにする。
+        normalized_tags = ",".join(quote(tag_name, safe="") for tag_name in sorted(tag_names))
+        return f"bookmark:list:tags:{normalized_tags}:v:{version}:{self._page_cache_fragment()}"

--- a/src/repositories/user.py
+++ b/src/repositories/user.py
@@ -1,6 +1,7 @@
 from ..dao.models.user import UserDao
 from ..dao.operators.user import UserDaoOperator
 from ..entities.user import UserEntity
+from ..libs.cache import query_cache
 from .base import BaseRepository
 
 
@@ -12,8 +13,8 @@ class UserRepository(BaseRepository):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.user_operator = UserDaoOperator(self.session, page=self.page)
-        self.loaded_user_dao: UserDao | None = None
 
+    @query_cache(key_func=lambda self, name: type(self)._find_one_cache_key(name))
     def find_one(self, /, name: str) -> UserEntity:
         """
         指定されたユーザー名に対応するユーザーを1件取得する。
@@ -31,10 +32,9 @@ class UserRepository(BaseRepository):
         if not user_dao:
             raise self.NotFoundError("Not found specified data.")
 
-        self.loaded_user_dao = user_dao
-
         return UserEntity(**user_dao.to_dict())
 
+    @query_cache(key_func=lambda self: self._find_all_cache_key())
     def find_all(self) -> list[UserEntity]:
         """
         全てのユーザーを取得する。
@@ -54,24 +54,39 @@ class UserRepository(BaseRepository):
         user_dao = UserDao(**user.model_dump())
 
         self.user_operator.save(user_dao)
+        # 詳細キーは直接削除し、一覧系は version を進めてまとめて無効化する。
+        self._delete_cache_keys(type(self)._find_one_cache_key(user.name))
+        self._bump_cache_versions("list")
 
-    def update_one(self, user: UserEntity) -> None:
+    def update_one(self, user: UserEntity, /, current_name: str) -> None:
         """
         既存のユーザー情報を更新する。
 
-        事前に `find_one()` を使用して更新対象のユーザーを取得しておく必要がある。
-
         Args:
             user: 更新するユーザーエンティティ
+            current_name: 更新対象の現在のユーザー名
 
         Raises:
-            Error: 更新対象のユーザーを取得(`find_one()`)していない
+            NotFoundError: 更新対象のユーザーが存在しない
         """
-        if self.loaded_user_dao is None:
-            raise self.Error("Not loaded user")
-
-        user_dao = self.loaded_user_dao
+        user_dao = self.user_operator.find_one_by_name(current_name)
+        if user_dao is None:
+            raise self.NotFoundError("Not found specified data.")
         for k, v in user.model_dump(exclude_none=True).items():
             setattr(user_dao, k, v)
 
         self.user_operator.save(user_dao)
+        # name 変更に備えて旧キーと新キーの両方を落とす。
+        self._delete_cache_keys(
+            type(self)._find_one_cache_key(current_name),
+            type(self)._find_one_cache_key(user_dao.name),
+        )
+        self._bump_cache_versions("list")
+
+    @staticmethod
+    def _find_one_cache_key(name: str) -> str:
+        return f"user:detail:{name}"
+
+    def _find_all_cache_key(self) -> str:
+        version = self._get_cache_version("list")
+        return f"user:list:v:{version}:{self._page_cache_fragment()}"

--- a/src/services/token_blacklist.py
+++ b/src/services/token_blacklist.py
@@ -4,7 +4,7 @@ from redis.exceptions import RedisError
 
 from ..libs.config import get_config
 from ..libs.log import get_logger
-from ..libs.redis_client import get_redis_client
+from ..libs.redis_client import get_blacklist_redis_client
 from .base import ServiceBase, ServiceError
 
 _logger = get_logger()
@@ -26,9 +26,9 @@ class TokenBlacklistService(ServiceBase):
         pass
 
     def __init__(self) -> None:
-        self.redis = get_redis_client()
-        self.fail_open = _config.redis_fail_open
-        self.default_ttl_seconds = _config.redis_blacklist_default_ttl_days * 24 * 60 * 60
+        self.redis = get_blacklist_redis_client()
+        self.fail_open = _config.blacklist_redis_fail_open
+        self.default_ttl_seconds = _config.blacklist_redis_default_ttl_days * 24 * 60 * 60
 
     def _handle_redis_error(self, exc: Exception, operation: str) -> None:
         """

--- a/src/usecases/bookmark.py
+++ b/src/usecases/bookmark.py
@@ -47,7 +47,7 @@ class BookmarkUsecase(UsecaseBase):
         for k, v in request_body.model_dump(exclude_none=True).items():
             setattr(bookmark, k, v)
 
-        self.bookmark_repository.update_one(bookmark)
+        self.bookmark_repository.update_one(bookmark, current_hashed_id=hashed_id)
 
         return {"updated_bookmark": bookmark.model_dump()}
 

--- a/src/usecases/user.py
+++ b/src/usecases/user.py
@@ -69,7 +69,7 @@ class UserUsecase(UsecaseBase):
             else:
                 setattr(user, k, v)
 
-        self.user_repository.update_one(user)
+        self.user_repository.update_one(user, current_name=name)
 
         return {"updated_user": user.to_response_dict()}
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,36 @@
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 import sys
 from pathlib import Path
+
+import pytest
+from dogpile.cache.region import CacheRegion
+from sqlalchemy import MetaData, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from src.libs.cache import create_memory_region
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+@contextmanager
+def _session_scope(metadata: MetaData) -> Iterator[Session]:
+    engine = create_engine("sqlite:///:memory:")
+    metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+    with session_factory() as db_session:
+        yield db_session
+
+
+@pytest.fixture
+def sqlite_session_factory() -> Callable[[MetaData], Iterator[Session]]:
+    # テストごとに独立した in-memory SQLite を組み立てる。
+    return _session_scope
+
+
+@pytest.fixture
+def memory_region() -> CacheRegion:
+    # unit テストでは副作用の少ないメモリキャッシュを共通利用する。
+    return create_memory_region()

--- a/tests/unit/factory.py
+++ b/tests/unit/factory.py
@@ -1,0 +1,58 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.dao.models.bookmark import BookmarkDao
+from src.dao.models.bookmark_tag import BookmarkTagDao
+from src.dao.models.tag import TagDao
+from src.dao.models.user import UserDao
+from src.libs.enum import AuthorityEnum
+from src.libs.util import get_hashed_id
+
+_UNIT_TEST_HASHED_PASSWORD = "hashed-password"
+
+
+class UnitDataFactory:
+    """
+    unit テスト用データ作成クラス
+    """
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def create_user(
+        self,
+        name: str,
+        disabled: bool = False,
+        authority: AuthorityEnum = AuthorityEnum.READWRITE,
+    ) -> UserDao:
+        user = UserDao(
+            name=name,
+            hashed_password=_UNIT_TEST_HASHED_PASSWORD,
+            disabled=disabled,
+            authority=authority.value,
+        )
+        self.session.add(user)
+        self.session.flush()
+        return user
+
+    def create_bookmark(self, url: str, memo: str, tag_names: list[str]) -> BookmarkDao:
+        bookmark = BookmarkDao(url=url, memo=memo, hashed_id=get_hashed_id(url))
+        self.session.add(bookmark)
+        self.session.flush()
+
+        for tag_name in tag_names:
+            tag = self._get_or_create_tag(tag_name)
+            self.session.add(BookmarkTagDao(bookmark_id=bookmark.id, tag_id=tag.id))
+        self.session.flush()
+        return bookmark
+
+    def _get_or_create_tag(self, name: str) -> TagDao:
+        # タグは bookmark 間で共有されるので、同名タグは再利用する。
+        tag = self.session.execute(select(TagDao).where(TagDao.name == name)).scalar_one_or_none()
+        if tag is not None:
+            return tag
+
+        tag = TagDao(name=name)
+        self.session.add(tag)
+        self.session.flush()
+        return tag

--- a/tests/unit/test_query_cache.py
+++ b/tests/unit/test_query_cache.py
@@ -2,8 +2,9 @@ from collections.abc import Iterator
 
 import pytest
 from dogpile.cache.api import NO_VALUE
-from sqlalchemy import Integer, String, create_engine, inspect as sa_inspect
-from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
+from dogpile.cache.region import CacheRegion
+from sqlalchemy import Integer, String, inspect as sa_inspect
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
 
 from src.libs.cache import NullCacheRegion, create_memory_region, create_redis_region, query_cache
 from src.libs.cache.key_generator import KeyGenerator
@@ -22,11 +23,8 @@ class Widget(Base):
 
 
 @pytest.fixture
-def session() -> Iterator[Session]:
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
-    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
-    with session_factory() as db_session:
+def session(sqlite_session_factory) -> Iterator[Session]:
+    with sqlite_session_factory(Base.metadata) as db_session:
         yield db_session
 
 
@@ -104,14 +102,14 @@ def test_template_key_generator_binds_argument_names(session: Session) -> None:
     assert key_func(session, 7) == "widget:7:False"
 
 
-def test_query_cache_caches_detached_model(session: Session) -> None:
+def test_query_cache_caches_detached_model(session: Session, memory_region: CacheRegion) -> None:
     """
     正常系:
     query_cache が detached な ORM オブジェクトをキャッシュする
     """
 
     # キャッシュリージョンとテストデータの準備
-    region = create_memory_region()
+    region = memory_region
     widget_id = _create_widget(session)
 
     class Repository:
@@ -177,14 +175,16 @@ def test_query_cache_supports_custom_session_and_region_attributes(session: Sess
     assert first_widget.id == second_widget.id == widget_id
 
 
-def test_query_cache_supports_function_style_with_session_argument(session: Session) -> None:
+def test_query_cache_supports_function_style_with_session_argument(
+    session: Session, memory_region: CacheRegion
+) -> None:
     """
     正常系:
     関数スタイルでも Session 引数からキャッシュできる
     """
 
     # キャッシュリージョンとテストデータの準備
-    region = create_memory_region()
+    region = memory_region
     widget_id = _create_widget(session)
     calls = 0
 
@@ -208,14 +208,14 @@ def test_query_cache_supports_function_style_with_session_argument(session: Sess
     assert sa_inspect(second_widget).detached
 
 
-def test_unless_skips_cache() -> None:
+def test_unless_skips_cache(memory_region: CacheRegion) -> None:
     """
     正常系:
     unless 条件が True の場合はキャッシュをスキップ
     """
 
     # キャッシュリージョンの準備
-    region = create_memory_region()
+    region = memory_region
     calls = 0
 
     # テスト対象関数の定義

--- a/tests/unit/test_repository_query_cache.py
+++ b/tests/unit/test_repository_query_cache.py
@@ -1,0 +1,345 @@
+from collections.abc import Iterator
+from threading import Barrier, Lock, Thread
+
+import pytest
+from dogpile.cache.api import NO_VALUE
+from dogpile.cache.region import CacheRegion
+from sqlalchemy.orm import Session
+
+from src.dao.models.base import BaseDao
+from src.dao.models.bookmark import BookmarkDao
+from src.dao.models.tag import TagDao
+from src.dao.models.user import UserDao
+from src.entities.bookmark import BookmarkEntity
+from src.entities.user import UserEntity
+from src.libs.enum import AuthorityEnum
+from src.libs.page import Page
+from src.libs.util import get_hashed_id
+from src.repositories.bookmark import BookmarkRepository
+from src.repositories.user import UserRepository
+from tests.unit.factory import UnitDataFactory
+
+
+@pytest.fixture
+def session(sqlite_session_factory) -> Iterator[Session]:
+    with sqlite_session_factory(BaseDao.metadata) as db_session:
+        yield db_session
+
+
+class ConcurrentVersionRegion:
+    """
+    初回 version 取得の競合を再現する、最小限のテスト用 region。
+    """
+
+    def __init__(self, parties: int) -> None:
+        self._value: object = NO_VALUE
+        self._barrier = Barrier(parties)
+        self._lock = Lock()
+
+    def get(
+        self, key: str, expiration_time: float | None = None, ignore_expiration: bool = False
+    ) -> object:
+        del key, expiration_time, ignore_expiration
+        self._barrier.wait()
+        return self._value
+
+    def get_or_create(self, key: str, creator, expiration_time: float | None = None) -> object:
+        del key, expiration_time
+        with self._lock:
+            if self._value is NO_VALUE:
+                self._value = creator()
+            return self._value
+
+    def set(self, key: str, value: object, expiration_time: int | None = None) -> None:
+        del key, expiration_time
+        self._value = value
+
+    def delete(self, key: str) -> None:
+        del key
+        self._value = NO_VALUE
+
+
+def test_user_repository_find_one_cache_and_invalidation(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    ユーザー詳細キャッシュは再利用され、更新後に無効化される
+    """
+    UnitDataFactory(session).create_user("alice")
+    repository = UserRepository(session, region=memory_region)
+
+    calls = 0
+    original = repository.user_operator.find_one_by_name
+
+    def wrapped(name: str) -> UserDao | None:
+        # 実 DB 参照回数を数え、2 回目以降が cache hit かを判定する。
+        nonlocal calls
+        calls += 1
+        return original(name)
+
+    monkeypatch.setattr(repository.user_operator, "find_one_by_name", wrapped)
+
+    first = repository.find_one(name="alice")
+    second = repository.find_one(name="alice")
+    assert first.name == second.name == "alice"
+    assert calls == 1
+
+    first.name = "alice-renamed"
+    first.disabled = True
+    repository.update_one(first, current_name="alice")
+
+    # 更新後は古い詳細キャッシュが無効化され、再度 DB を読む。
+    refreshed = repository.find_one(name="alice-renamed")
+    cached = repository.find_one(name="alice-renamed")
+    assert refreshed.name == cached.name == "alice-renamed"
+    assert refreshed.disabled is True
+    assert calls == 3
+
+
+def test_user_repository_find_all_cache_is_invalidated_on_add(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    ユーザー一覧キャッシュは追加後に無効化される
+    """
+    UnitDataFactory(session).create_user("alice")
+    repository = UserRepository(
+        session,
+        page=Page(number=1, size=10),
+        region=memory_region,
+    )
+
+    calls = 0
+    original = repository.user_operator.find_all
+
+    def wrapped() -> list[UserDao]:
+        # 一覧キャッシュの有無を DB 呼び出し回数で見る。
+        nonlocal calls
+        calls += 1
+        return original()
+
+    monkeypatch.setattr(repository.user_operator, "find_all", wrapped)
+
+    first = repository.find_all()
+    second = repository.find_all()
+    assert sorted(user.name for user in first) == sorted(user.name for user in second) == ["alice"]
+    assert calls == 1
+
+    repository.add_one(
+        UserEntity(
+            name="bob",
+            hashed_password="hashed-password",
+            disabled=False,
+            authority=AuthorityEnum.READWRITE,
+        )
+    )
+
+    # add 後は一覧 version が進み、一覧クエリが再評価される。
+    refreshed = repository.find_all()
+    cached = repository.find_all()
+    assert sorted(user.name for user in refreshed) == ["alice", "bob"]
+    assert sorted(user.name for user in cached) == ["alice", "bob"]
+    assert calls == 2
+
+
+def test_bookmark_repository_find_one_cache_and_invalidation(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    ブックマーク詳細キャッシュは再利用され、更新後に無効化される
+    """
+    bookmark = UnitDataFactory(session).create_bookmark(
+        "https://example.com/1",
+        "before",
+        ["tag1"],
+    )
+    repository = BookmarkRepository(session, region=memory_region)
+
+    bookmark_calls = 0
+    tag_calls = 0
+    original_find_one = repository.bookmark_operator.find_one_by_hashed_id
+    original_find_tags = repository.tag_operator.find_by_bookmark_id
+
+    def wrapped_find_one(hashed_id: str) -> BookmarkDao | None:
+        # 本体 bookmark 取得クエリの呼び出し回数を追跡する。
+        nonlocal bookmark_calls
+        bookmark_calls += 1
+        return original_find_one(hashed_id)
+
+    def wrapped_find_tags(bookmark_id: int) -> list[TagDao]:
+        # タグ解決クエリも別に数え、詳細全体が cache hit していることを確認する。
+        nonlocal tag_calls
+        tag_calls += 1
+        return original_find_tags(bookmark_id)
+
+    monkeypatch.setattr(repository.bookmark_operator, "find_one_by_hashed_id", wrapped_find_one)
+    monkeypatch.setattr(repository.tag_operator, "find_by_bookmark_id", wrapped_find_tags)
+
+    first = repository.find_one(hashed_id=bookmark.hashed_id)
+    second = repository.find_one(hashed_id=bookmark.hashed_id)
+    assert first.memo == second.memo == "before"
+    assert first.tags == second.tags == ["tag1"]
+    assert bookmark_calls == 1
+    assert tag_calls == 1
+
+    first.memo = "after"
+    first.tags = ["tag2"]
+    repository.update_one(first, current_hashed_id=bookmark.hashed_id)
+
+    # 更新後は詳細キャッシュが無効化され、タグも含めて再取得される。
+    refreshed = repository.find_one(hashed_id=bookmark.hashed_id)
+    cached = repository.find_one(hashed_id=bookmark.hashed_id)
+    assert refreshed.memo == cached.memo == "after"
+    assert refreshed.tags == cached.tags == ["tag2"]
+    assert bookmark_calls == 3
+    assert tag_calls == 2
+
+
+def test_bookmark_repository_tag_list_cache_normalizes_key_and_invalidates_on_add(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    タグ検索一覧キャッシュはタグ順を正規化し、追加後に無効化される
+    """
+    UnitDataFactory(session).create_bookmark("https://example.com/1", "first", ["tag1", "tag2"])
+    repository = BookmarkRepository(
+        session,
+        page=Page(number=1, size=10),
+        region=memory_region,
+    )
+
+    calls = 0
+    original = repository.bookmark_operator.find_by_tags
+
+    def wrapped(tag_names: list[str]) -> list[BookmarkDao]:
+        # タグ一覧クエリの実行回数で、キー正規化と無効化の両方を確認する。
+        nonlocal calls
+        calls += 1
+        return original(tag_names)
+
+    monkeypatch.setattr(repository.bookmark_operator, "find_by_tags", wrapped)
+
+    # タグ順が違っても同じ検索条件として同一キーを使う。
+    first = repository.find_by_tags(["tag1", "tag2"])
+    second = repository.find_by_tags(["tag2", "tag1"])
+    assert sorted(bookmark.memo for bookmark in first) == ["first"]
+    assert sorted(bookmark.memo for bookmark in second) == ["first"]
+    assert calls == 1
+
+    repository.add_one(
+        BookmarkEntity(
+            hashed_id=get_hashed_id("https://example.com/2"),
+            url="https://example.com/2",
+            memo="second",
+            tags=["tag1", "tag2"],
+        )
+    )
+
+    # add 後は tag-list version が進み、同じタグ条件でも再検索される。
+    refreshed = repository.find_by_tags(["tag1", "tag2"])
+    cached = repository.find_by_tags(["tag2", "tag1"])
+    assert sorted(bookmark.memo for bookmark in refreshed) == ["first", "second"]
+    assert sorted(bookmark.memo for bookmark in cached) == ["first", "second"]
+    assert calls == 2
+
+
+def test_bookmark_repository_tag_list_cache_escapes_delimiters(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    区切り文字を含むタグでも別条件の検索キーと衝突しない
+    """
+    factory = UnitDataFactory(session)
+    factory.create_bookmark("https://example.com/1", "first", ["a,b", "c"])
+    factory.create_bookmark("https://example.com/2", "second", ["a", "b,c"])
+    repository = BookmarkRepository(
+        session,
+        page=Page(number=1, size=10),
+        region=memory_region,
+    )
+
+    calls = 0
+    original = repository.bookmark_operator.find_by_tags
+
+    def wrapped(tag_names: list[str]) -> list[BookmarkDao]:
+        # 条件が異なる 2 回の検索で、それぞれ別キーが使われることを確認する。
+        nonlocal calls
+        calls += 1
+        return original(tag_names)
+
+    monkeypatch.setattr(repository.bookmark_operator, "find_by_tags", wrapped)
+
+    first = repository.find_by_tags(["a,b", "c"])
+    second = repository.find_by_tags(["a", "b,c"])
+    cached_first = repository.find_by_tags(["c", "a,b"])
+    cached_second = repository.find_by_tags(["b,c", "a"])
+
+    assert sorted(bookmark.memo for bookmark in first) == ["first"]
+    assert sorted(bookmark.memo for bookmark in second) == ["second"]
+    assert sorted(bookmark.memo for bookmark in cached_first) == ["first"]
+    assert sorted(bookmark.memo for bookmark in cached_second) == ["second"]
+    assert calls == 2
+
+
+def test_bump_cache_versions_does_not_depend_on_current_version(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    version 更新は現在値の read-modify-write に依存せず新しい一意値へ置き換える
+    """
+    repository = UserRepository(session, region=memory_region)
+
+    def fail_get_version(namespace: str) -> str:
+        raise AssertionError(f"_get_cache_version should not be called during bump: {namespace}")
+
+    monkeypatch.setattr(repository, "_get_cache_version", fail_get_version)
+
+    repository._bump_cache_versions("list")
+    first_version = repository.region.get(repository._cache_version_key("list"))
+    repository._bump_cache_versions("list")
+    second_version = repository.region.get(repository._cache_version_key("list"))
+
+    assert isinstance(first_version, str)
+    assert isinstance(second_version, str)
+    assert first_version != second_version
+
+
+def test_get_cache_version_initialization_is_atomic(session: Session) -> None:
+    """
+    正常系:
+    初回 version 生成が並行しても同じ値に収束する
+    """
+    region = ConcurrentVersionRegion(parties=4)
+    repository = UserRepository(session, region=region)
+    versions: list[str] = []
+
+    def worker() -> None:
+        # 初期 version 生成は region.get_or_create() に集約され、並行時も 1 値だけ返る。
+        versions.append(repository._get_cache_version("list"))
+
+    threads = [Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(versions) == 4
+    assert len(set(versions)) == 1


### PR DESCRIPTION
## 概要
- repository層にクエリキャッシュを導入し、実際の read クエリ結果をキャッシュ
- 更新系処理で詳細・一覧・タグ検索キャッシュが適切に無効化されるように対応
- クエリキャッシュ用 Redis 設定と blacklist 用 Redis 設定を分離し、テストを追加

## 主な変更
- `UserRepository` / `BookmarkRepository` の read 処理にキャッシュ適用
- 一覧系は namespace version、詳細系はキー削除で無効化
- query cache region provider を追加し、未設定時は `NullCacheRegion` を使用
- blacklist Redis 環境変数を `BLACKLIST_REDIS_*` に統一
- unit test の共通セットアップを `conftest.py` / `factory.py` に整理
- repository cache の回帰テストを追加
