### PR TITLE
クエリキャッシュのテストを拡充

### DIFF
--- a/src/repositories/bookmark.py
+++ b/src/repositories/bookmark.py
@@ -184,6 +184,6 @@ class BookmarkRepository(BaseRepository):
 
     def _find_by_tags_cache_key(self, tag_names: list[str]) -> str:
         version = self._get_cache_version("tag-list")
-        # 各タグ名をエスケープして連結し、区切り文字を含むタグでもキー衝突しないようにする。
-        normalized_tags = ",".join(quote(tag_name, safe="") for tag_name in sorted(tag_names))
+        # タグ順や重複に依存しないように正規化し、区切り文字を含むタグでもキー衝突しないようにする。
+        normalized_tags = ",".join(quote(tag_name, safe="") for tag_name in sorted(set(tag_names)))
         return f"bookmark:list:tags:{normalized_tags}:v:{version}:{self._page_cache_fragment()}"

--- a/tests/unit/test_query_cache.py
+++ b/tests/unit/test_query_cache.py
@@ -102,6 +102,33 @@ def test_template_key_generator_binds_argument_names(session: Session) -> None:
     assert key_func(session, 7) == "widget:7:False"
 
 
+def test_default_key_sorts_keyword_arguments(session: Session) -> None:
+    """
+    正常系:
+    デフォルトキー生成は kwargs の順序差を正規化する
+    """
+
+    # テスト対象関数の定義
+    def load_widget(
+        db: Session, widget_id: int, include_deleted: bool = False, limit: int = 10
+    ) -> None:
+        del db, widget_id, include_deleted, limit
+
+    # kwargs の投入順が違っても、同じキーに正規化されることを確認する。
+    first = KeyGenerator.default(
+        load_widget,
+        (session, 7),
+        {"include_deleted": True, "limit": 20},
+    )
+    second = KeyGenerator.default(
+        load_widget,
+        (session, 7),
+        {"limit": 20, "include_deleted": True},
+    )
+
+    assert first == second
+
+
 def test_query_cache_caches_detached_model(session: Session, memory_region: CacheRegion) -> None:
     """
     正常系:
@@ -138,6 +165,58 @@ def test_query_cache_caches_detached_model(session: Session, memory_region: Cach
     assert first_widget.id == second_widget.id == widget_id
     assert sa_inspect(first_widget).detached
     assert sa_inspect(second_widget).detached
+
+
+def test_query_cache_caches_none_result(memory_region: CacheRegion) -> None:
+    """
+    正常系:
+    query_cache は None も有効なキャッシュ値として保持する
+    """
+
+    # キャッシュリージョンの準備
+    region = memory_region
+    calls = 0
+
+    # テスト対象関数の定義
+    @query_cache(region=region, key_func="widget:{widget_id}")
+    def load_widget(widget_id: int) -> Widget | None:
+        nonlocal calls
+        calls += 1
+        return None
+
+    first = load_widget(7)
+    second = load_widget(7)
+
+    # None は miss 扱いされず、2 回目は関数本体を再実行しない。
+    assert first is None
+    assert second is None
+    assert calls == 1
+
+
+def test_query_cache_caches_empty_list(memory_region: CacheRegion) -> None:
+    """
+    正常系:
+    query_cache は空リストも有効なキャッシュ値として保持する
+    """
+
+    # キャッシュリージョンの準備
+    region = memory_region
+    calls = 0
+
+    # テスト対象関数の定義
+    @query_cache(region=region, key_func="widgets:{prefix}")
+    def load_widgets(prefix: str) -> list[Widget]:
+        nonlocal calls
+        calls += 1
+        return []
+
+    first = load_widgets("missing")
+    second = load_widgets("missing")
+
+    # 空リストも miss 扱いされず、2 回目は cache hit する。
+    assert first == []
+    assert second == []
+    assert calls == 1
 
 
 def test_query_cache_supports_custom_session_and_region_attributes(session: Session) -> None:

--- a/tests/unit/test_repository_query_cache.py
+++ b/tests/unit/test_repository_query_cache.py
@@ -99,6 +99,38 @@ def test_user_repository_find_one_cache_and_invalidation(
     assert calls == 3
 
 
+def test_user_repository_find_one_not_found_is_not_cached(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    未存在ユーザーの詳細取得はキャッシュされず毎回再評価される
+    """
+    repository = UserRepository(session, region=memory_region)
+
+    calls = 0
+    original = repository.user_operator.find_one_by_name
+
+    def wrapped(name: str) -> UserDao | None:
+        # NotFoundError で終わるケースでも、都度 DB 参照が走ることを確認する。
+        nonlocal calls
+        calls += 1
+        return original(name)
+
+    monkeypatch.setattr(repository.user_operator, "find_one_by_name", wrapped)
+
+    with pytest.raises(UserRepository.NotFoundError, match="Not found specified data."):
+        repository.find_one(name="missing-user")
+
+    with pytest.raises(UserRepository.NotFoundError, match="Not found specified data."):
+        repository.find_one(name="missing-user")
+
+    # 例外結果はキャッシュされず、毎回 DAO が呼ばれる。
+    assert calls == 2
+
+
 def test_user_repository_find_all_cache_is_invalidated_on_add(
     session: Session,
     memory_region: CacheRegion,
@@ -146,6 +178,130 @@ def test_user_repository_find_all_cache_is_invalidated_on_add(
     assert sorted(user.name for user in refreshed) == ["alice", "bob"]
     assert sorted(user.name for user in cached) == ["alice", "bob"]
     assert calls == 2
+
+
+def test_user_repository_find_all_cache_separates_page_number(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    ユーザー一覧キャッシュはページ番号ごとに別キーになる
+    """
+    UnitDataFactory(session).create_user("alice")
+    UnitDataFactory(session).create_user("bob")
+    first_page_repository = UserRepository(
+        session,
+        page=Page(number=1, size=1),
+        region=memory_region,
+    )
+    second_page_repository = UserRepository(
+        session,
+        page=Page(number=2, size=1),
+        region=memory_region,
+    )
+
+    first_page_calls = 0
+    second_page_calls = 0
+    original_first_page = first_page_repository.user_operator.find_all
+    original_second_page = second_page_repository.user_operator.find_all
+
+    def wrapped_first_page() -> list[UserDao]:
+        # 同じ region を共有しても、ページ番号が違えば別クエリとして評価されることを見る。
+        nonlocal first_page_calls
+        first_page_calls += 1
+        return original_first_page()
+
+    def wrapped_second_page() -> list[UserDao]:
+        # page=2 の取得が page=1 のキャッシュを誤 reuse しないことを見る。
+        nonlocal second_page_calls
+        second_page_calls += 1
+        return original_second_page()
+
+    monkeypatch.setattr(first_page_repository.user_operator, "find_all", wrapped_first_page)
+    monkeypatch.setattr(second_page_repository.user_operator, "find_all", wrapped_second_page)
+
+    first_page = first_page_repository.find_all()
+    cached_first_page = first_page_repository.find_all()
+    second_page = second_page_repository.find_all()
+    cached_second_page = second_page_repository.find_all()
+
+    # 各ページは最初の 1 回だけ DB に到達し、同一ページ内では cache hit する。
+    assert len(first_page) == len(cached_first_page) == 1
+    assert len(second_page) == len(cached_second_page) == 1
+    assert first_page_calls == 1
+    assert second_page_calls == 1
+
+
+def test_user_repository_find_all_cache_invalidation_reaches_all_pages(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    ユーザー一覧キャッシュの無効化は別ページの一覧にも伝播する
+    """
+    UnitDataFactory(session).create_user("alice")
+    UnitDataFactory(session).create_user("bob")
+    first_page_repository = UserRepository(
+        session,
+        page=Page(number=1, size=1),
+        region=memory_region,
+    )
+    second_page_repository = UserRepository(
+        session,
+        page=Page(number=2, size=1),
+        region=memory_region,
+    )
+
+    first_page_calls = 0
+    second_page_calls = 0
+    original_first_page = first_page_repository.user_operator.find_all
+    original_second_page = second_page_repository.user_operator.find_all
+
+    def wrapped_first_page() -> list[UserDao]:
+        # 追加前後で page=1 の一覧が再評価されるかを追跡する。
+        nonlocal first_page_calls
+        first_page_calls += 1
+        return original_first_page()
+
+    def wrapped_second_page() -> list[UserDao]:
+        # version bump により page=2 の一覧も巻き込んで無効化されることを見る。
+        nonlocal second_page_calls
+        second_page_calls += 1
+        return original_second_page()
+
+    monkeypatch.setattr(first_page_repository.user_operator, "find_all", wrapped_first_page)
+    monkeypatch.setattr(second_page_repository.user_operator, "find_all", wrapped_second_page)
+
+    first_page_repository.find_all()
+    first_page_repository.find_all()
+    second_page_repository.find_all()
+    second_page_repository.find_all()
+    assert first_page_calls == 1
+    assert second_page_calls == 1
+
+    first_page_repository.add_one(
+        UserEntity(
+            name="charlie",
+            hashed_password="hashed-password",
+            disabled=False,
+            authority=AuthorityEnum.READWRITE,
+        )
+    )
+
+    refreshed_first_page = first_page_repository.find_all()
+    cached_first_page = first_page_repository.find_all()
+    refreshed_second_page = second_page_repository.find_all()
+    cached_second_page = second_page_repository.find_all()
+
+    # list namespace の version が進むと、全ページ条件で 1 回ずつ再クエリされる。
+    assert len(refreshed_first_page) == len(cached_first_page) == 1
+    assert len(refreshed_second_page) == len(cached_second_page) == 1
+    assert first_page_calls == 2
+    assert second_page_calls == 2
 
 
 def test_bookmark_repository_find_one_cache_and_invalidation(
@@ -202,6 +358,117 @@ def test_bookmark_repository_find_one_cache_and_invalidation(
     assert refreshed.tags == cached.tags == ["tag2"]
     assert bookmark_calls == 3
     assert tag_calls == 2
+
+
+def test_bookmark_repository_find_one_not_found_is_not_cached(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    未存在ブックマークの詳細取得はキャッシュされず毎回再評価される
+    """
+    repository = BookmarkRepository(session, region=memory_region)
+
+    bookmark_calls = 0
+    original = repository.bookmark_operator.find_one_by_hashed_id
+
+    def wrapped(hashed_id: str) -> BookmarkDao | None:
+        # 未ヒット時もキャッシュせず、毎回 bookmark 本体を問い合わせることを見る。
+        nonlocal bookmark_calls
+        bookmark_calls += 1
+        return original(hashed_id)
+
+    monkeypatch.setattr(repository.bookmark_operator, "find_one_by_hashed_id", wrapped)
+
+    with pytest.raises(BookmarkRepository.NotFoundError, match="Not found specified data."):
+        repository.find_one(hashed_id="missing-bookmark")
+
+    with pytest.raises(BookmarkRepository.NotFoundError, match="Not found specified data."):
+        repository.find_one(hashed_id="missing-bookmark")
+
+    # 例外結果はキャッシュされず、毎回 DAO が呼ばれる。
+    assert bookmark_calls == 2
+
+
+def test_bookmark_repository_delete_one_invalidates_detail_and_lists(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    ブックマーク削除後は詳細・一覧・タグ一覧キャッシュが無効化される
+    """
+    factory = UnitDataFactory(session)
+    bookmark = factory.create_bookmark("https://example.com/1", "first", ["tag1"])
+    factory.create_bookmark("https://example.com/2", "second", ["tag2"])
+    repository = BookmarkRepository(
+        session,
+        page=Page(number=1, size=10),
+        region=memory_region,
+    )
+
+    detail_calls = 0
+    list_calls = 0
+    tag_list_calls = 0
+    original_find_one = repository.bookmark_operator.find_one_by_hashed_id
+    original_find_all = repository.bookmark_operator.find_all
+    original_find_by_tags = repository.bookmark_operator.find_by_tags
+
+    def wrapped_find_one(hashed_id: str) -> BookmarkDao | None:
+        # 詳細キャッシュの有無と、delete 時の再参照を同じカウンタで追跡する。
+        nonlocal detail_calls
+        detail_calls += 1
+        return original_find_one(hashed_id)
+
+    def wrapped_find_all() -> list[BookmarkDao]:
+        # 全件一覧が delete 後に再評価されるかを確認する。
+        nonlocal list_calls
+        list_calls += 1
+        return original_find_all()
+
+    def wrapped_find_by_tags(tag_names: list[str]) -> list[BookmarkDao]:
+        # タグ検索一覧も version bump で巻き込んで無効化されることを見る。
+        nonlocal tag_list_calls
+        tag_list_calls += 1
+        return original_find_by_tags(tag_names)
+
+    monkeypatch.setattr(repository.bookmark_operator, "find_one_by_hashed_id", wrapped_find_one)
+    monkeypatch.setattr(repository.bookmark_operator, "find_all", wrapped_find_all)
+    monkeypatch.setattr(repository.bookmark_operator, "find_by_tags", wrapped_find_by_tags)
+
+    repository.find_one(hashed_id=bookmark.hashed_id)
+    repository.find_one(hashed_id=bookmark.hashed_id)
+    repository.find_all()
+    repository.find_all()
+    repository.find_by_tags(["tag1"])
+    repository.find_by_tags(["tag1"])
+    assert detail_calls == 1
+    assert list_calls == 1
+    assert tag_list_calls == 1
+
+    repository.delete_one(hashed_id=bookmark.hashed_id)
+
+    # delete 実行時に対象 bookmark を解決するため、詳細 DAO は 1 回追加で呼ばれる。
+    assert detail_calls == 2
+
+    with pytest.raises(BookmarkRepository.NotFoundError, match="Not found specified data."):
+        repository.find_one(hashed_id=bookmark.hashed_id)
+
+    refreshed_list = repository.find_all()
+    cached_list = repository.find_all()
+    refreshed_tag_list = repository.find_by_tags(["tag1"])
+    cached_tag_list = repository.find_by_tags(["tag1"])
+
+    # 削除後は詳細が見つからず、一覧系は 1 回ずつ再評価されたうえで cache hit する。
+    assert detail_calls == 3
+    assert sorted(bookmark.memo for bookmark in refreshed_list) == ["second"]
+    assert sorted(bookmark.memo for bookmark in cached_list) == ["second"]
+    assert refreshed_tag_list == cached_tag_list == []
+    assert list_calls == 2
+    assert tag_list_calls == 2
 
 
 def test_bookmark_repository_tag_list_cache_normalizes_key_and_invalidates_on_add(
@@ -294,6 +561,168 @@ def test_bookmark_repository_tag_list_cache_escapes_delimiters(
     assert sorted(bookmark.memo for bookmark in cached_first) == ["first"]
     assert sorted(bookmark.memo for bookmark in cached_second) == ["second"]
     assert calls == 2
+
+
+def test_bookmark_repository_tag_list_cache_normalizes_duplicate_tags(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    タグ検索一覧キャッシュは重複タグも同一条件として正規化する
+    """
+    UnitDataFactory(session).create_bookmark("https://example.com/1", "first", ["tag1"])
+    repository = BookmarkRepository(
+        session,
+        page=Page(number=1, size=10),
+        region=memory_region,
+    )
+
+    calls = 0
+    original = repository.bookmark_operator.find_by_tags
+
+    def wrapped(tag_names: list[str]) -> list[BookmarkDao]:
+        # SQL 上は同義な ["tag1"] と ["tag1", "tag1"] が同じキーを使うことを見る。
+        nonlocal calls
+        calls += 1
+        return original(tag_names)
+
+    monkeypatch.setattr(repository.bookmark_operator, "find_by_tags", wrapped)
+
+    first = repository.find_by_tags(["tag1"])
+    second = repository.find_by_tags(["tag1", "tag1"])
+
+    # 重複タグを含む条件でも、同一検索として cache hit する。
+    assert sorted(bookmark.memo for bookmark in first) == ["first"]
+    assert sorted(bookmark.memo for bookmark in second) == ["first"]
+    assert calls == 1
+
+
+def test_bookmark_repository_tag_list_cache_separates_page_size(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    タグ検索一覧キャッシュはページサイズごとに別キーになる
+    """
+    factory = UnitDataFactory(session)
+    factory.create_bookmark("https://example.com/1", "first", ["tag1"])
+    factory.create_bookmark("https://example.com/2", "second", ["tag1"])
+    small_page_repository = BookmarkRepository(
+        session,
+        page=Page(number=1, size=1),
+        region=memory_region,
+    )
+    large_page_repository = BookmarkRepository(
+        session,
+        page=Page(number=1, size=2),
+        region=memory_region,
+    )
+
+    small_page_calls = 0
+    large_page_calls = 0
+    original_small_page = small_page_repository.bookmark_operator.find_by_tags
+    original_large_page = large_page_repository.bookmark_operator.find_by_tags
+
+    def wrapped_small_page(tag_names: list[str]) -> list[BookmarkDao]:
+        # size=1 の取得が size=2 のキャッシュと混ざらないことを確認する。
+        nonlocal small_page_calls
+        small_page_calls += 1
+        return original_small_page(tag_names)
+
+    def wrapped_large_page(tag_names: list[str]) -> list[BookmarkDao]:
+        # 同じタグ条件でもページサイズが違えば別キーで評価されることを見る。
+        nonlocal large_page_calls
+        large_page_calls += 1
+        return original_large_page(tag_names)
+
+    monkeypatch.setattr(small_page_repository.bookmark_operator, "find_by_tags", wrapped_small_page)
+    monkeypatch.setattr(large_page_repository.bookmark_operator, "find_by_tags", wrapped_large_page)
+
+    small_page = small_page_repository.find_by_tags(["tag1"])
+    cached_small_page = small_page_repository.find_by_tags(["tag1"])
+    large_page = large_page_repository.find_by_tags(["tag1"])
+    cached_large_page = large_page_repository.find_by_tags(["tag1"])
+
+    # ページサイズごとに 1 回ずつ DB を読み、同一条件では cache hit する。
+    assert len(small_page) == len(cached_small_page) == 1
+    assert len(large_page) == len(cached_large_page) == 2
+    assert small_page_calls == 1
+    assert large_page_calls == 1
+
+
+def test_bookmark_repository_tag_list_cache_invalidation_reaches_all_pages(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    タグ検索一覧キャッシュの無効化は別ページ条件の一覧にも伝播する
+    """
+    factory = UnitDataFactory(session)
+    factory.create_bookmark("https://example.com/1", "first", ["tag1"])
+    factory.create_bookmark("https://example.com/2", "second", ["tag1"])
+    small_page_repository = BookmarkRepository(
+        session,
+        page=Page(number=1, size=1),
+        region=memory_region,
+    )
+    large_page_repository = BookmarkRepository(
+        session,
+        page=Page(number=1, size=2),
+        region=memory_region,
+    )
+
+    small_page_calls = 0
+    large_page_calls = 0
+    original_small_page = small_page_repository.bookmark_operator.find_by_tags
+    original_large_page = large_page_repository.bookmark_operator.find_by_tags
+
+    def wrapped_small_page(tag_names: list[str]) -> list[BookmarkDao]:
+        # 追加前後で size=1 のタグ検索一覧が再評価されるかを追跡する。
+        nonlocal small_page_calls
+        small_page_calls += 1
+        return original_small_page(tag_names)
+
+    def wrapped_large_page(tag_names: list[str]) -> list[BookmarkDao]:
+        # tag-list version の更新が size=2 の一覧にも波及することを見る。
+        nonlocal large_page_calls
+        large_page_calls += 1
+        return original_large_page(tag_names)
+
+    monkeypatch.setattr(small_page_repository.bookmark_operator, "find_by_tags", wrapped_small_page)
+    monkeypatch.setattr(large_page_repository.bookmark_operator, "find_by_tags", wrapped_large_page)
+
+    small_page_repository.find_by_tags(["tag1"])
+    small_page_repository.find_by_tags(["tag1"])
+    large_page_repository.find_by_tags(["tag1"])
+    large_page_repository.find_by_tags(["tag1"])
+    assert small_page_calls == 1
+    assert large_page_calls == 1
+
+    small_page_repository.add_one(
+        BookmarkEntity(
+            hashed_id=get_hashed_id("https://example.com/3"),
+            url="https://example.com/3",
+            memo="third",
+            tags=["tag1"],
+        )
+    )
+
+    refreshed_small_page = small_page_repository.find_by_tags(["tag1"])
+    cached_small_page = small_page_repository.find_by_tags(["tag1"])
+    refreshed_large_page = large_page_repository.find_by_tags(["tag1"])
+    cached_large_page = large_page_repository.find_by_tags(["tag1"])
+
+    # tag-list namespace の version が進むと、全ページ条件で 1 回ずつ再検索される。
+    assert len(refreshed_small_page) == len(cached_small_page) == 1
+    assert len(refreshed_large_page) == len(cached_large_page) == 2
+    assert small_page_calls == 2
+    assert large_page_calls == 2
 
 
 def test_bump_cache_versions_does_not_depend_on_current_version(


### PR DESCRIPTION
## 概要
以下のテストを追加
- ページ条件ごとにキャッシュキーが分離される
- 無効化が別ページにも伝播する
- NotFound の非キャッシュ
- None と空リストのキャッシュ
- kwargs 順序差のキー正規化

以下を改善
- ブックマークのタグ一覧キャッシュキー生成で、重複タグも同一条件として正規化するよう改善
