### PR TITLE
コミット後にキャッシュ無効化を実行するよう修正

### DIFF
--- a/docs/query_cache_design.md
+++ b/docs/query_cache_design.md
@@ -199,6 +199,12 @@ wrapper(*args, **kwargs) が呼ばれる
     │
     ├─ unless(*args, **kwargs) == True → キャッシュスキップ、関数をそのまま実行
     │
+    ├─ session = SessionResolver.resolve(args, kwargs)
+    │
+    ├─ has_pending_cache_invalidation(session, region) == True
+    │   └─ 関数を実行し、必要なら expunge してそのまま返す
+    │      (stale cache の再利用/再生成を避けるため cache bypass)
+    │
     ├─ cache_key = KeyGenerator.generate(key_func, func, args, kwargs)
     │
     ├─ cached = region.get(cache_key)
@@ -422,18 +428,26 @@ def get_by_id(self, user_id: int) -> User | None:
 
 ## 6. キャッシュ削除
 
-デコレータはキャッシュ削除を自動では行わない。
-削除は呼び出し元が明示的に行う。
+読み込みキャッシュの付与は `@query_cache` デコレータが担う。
+一方、書き込み後の無効化は repository が Session に予約を積み、commit 完了後に共通リスナーが実行する。
+予約は Session 全体ではなく transaction 単位で保持し、nested transaction の rollback では対象 transaction 配下の予約だけを破棄する。
 
 ```python
-# SQLAlchemy イベントで自動削除
-from sqlalchemy import event
+# repository 側では commit 後に消したいキーだけを予約する
+schedule_cache_key_deletes(session, region, f"user:{user.name}")
+schedule_cache_version_bumps(session, region, user_list_version_key)
 
-@event.listens_for(Session, "after_flush")
-def after_flush(session, flush_context):
-    for obj in session.dirty | session.deleted:
-        if isinstance(obj, User):
-            region.delete(f"user:{obj.id}")
+
+@event.listens_for(Session, "after_commit")
+def after_commit(session):
+    # Session に積まれた予約をまとめて反映する
+    ...
+
+
+@event.listens_for(Session, "after_soft_rollback")
+def after_soft_rollback(session, previous_transaction):
+    # rollback 対象 transaction 配下の予約だけを破棄する
+    ...
 ```
 
 ---
@@ -453,7 +467,7 @@ def after_flush(session, flush_context):
 
 | 項目 | 方針 |
 |---|---|
-| スレッドセーフ | dogpile.cache の dogpile lock に依存 |
+| スレッドセーフ | query 結果キャッシュは dogpile lock に依存し、Session event listener 登録は専用 lock で多重登録を防ぐ |
 | 型安全 | `Callable` の型ヒントを付与。mypy 対応 |
 | ログ | `logging` モジュールを使用。キャッシュHIT/MISS を DEBUG レベルで出力 |
 | テスト | `ZstdMemoryBackend` を使って単体テスト可能 |

--- a/src/libs/cache/decorator.py
+++ b/src/libs/cache/decorator.py
@@ -6,6 +6,7 @@ from dogpile.cache.api import NO_VALUE
 from dogpile.cache.region import CacheRegion
 
 from ..log import get_logger
+from .invalidation import has_pending_cache_invalidation
 from .key_generator import KeyFunc, KeyGenerator
 from .region import NullCacheRegion
 from .session_resolver import SessionResolver
@@ -16,6 +17,10 @@ _logger = get_logger()
 
 
 class _CacheRegionLike(Protocol):
+    """
+    query_cache が依存する最小限のキャッシュリージョン操作を表す Protocol。
+    """
+
     def get(
         self,
         key: str,
@@ -62,6 +67,20 @@ def query_cache(
             if unless is not None and unless(*args, **kwargs):
                 return func(*args, **kwargs)
 
+            # 戻り値の detach 判定に使う Session を先に解決しておく。
+            session = session_resolver.resolve(args, dict(kwargs))
+
+            def execute_and_prepare_result() -> T:
+                result = func(*args, **kwargs)
+                if session is not None:
+                    # Session に紐づいた ORM オブジェクトのままキャッシュしない。
+                    session_resolver.expunge(session, result)
+                return result
+
+            if has_pending_cache_invalidation(session, cache_region):
+                # 同一 transaction 内で無効化待ちがある間は、stale cache の再利用/再生成を避ける。
+                return execute_and_prepare_result()
+
             cache_key = KeyGenerator.generate(
                 key_func,
                 func,
@@ -76,18 +95,11 @@ def query_cache(
 
             _logger.debug("Query cache MISS: %s", cache_key)
 
-            def creator() -> T:
-                result = func(*args, **kwargs)
-                session = session_resolver.resolve(args, dict(kwargs))
-                if session is not None:
-                    session_resolver.expunge(session, result)
-                return result
-
             return cast(
                 T,
                 cache_region.get_or_create(
                     cache_key,
-                    creator,
+                    execute_and_prepare_result,
                     expiration_time=expiration_time,
                 ),
             )

--- a/src/libs/cache/invalidation.py
+++ b/src/libs/cache/invalidation.py
@@ -1,0 +1,287 @@
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any, Protocol
+from uuid import uuid4
+
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+
+_PENDING_INVALIDATIONS_SESSION_KEY = "bookmark.pending_cache_invalidations"
+_LISTENERS_INSTALLED = False
+_LISTENERS_LOCK = Lock()
+
+
+class _CacheRegionLike(Protocol):
+    """
+    commit 後無効化で必要な最小限のキャッシュリージョン操作を表す Protocol。
+    """
+
+    def set(self, key: str, value: Any) -> None: ...
+
+    def delete(self, key: str) -> None: ...
+
+
+@dataclass
+class _PendingInvalidation:
+    """
+    1 つのキャッシュリージョンに対して保留中の無効化内容をまとめるデータ。
+    """
+
+    region: _CacheRegionLike
+    keys: set[str] = field(default_factory=set)
+    version_keys: set[str] = field(default_factory=set)
+
+
+@dataclass
+class _PendingTransactionInvalidation:
+    """
+    1 つのトランザクションに紐づく保留中無効化をリージョン単位で保持するデータ。
+    """
+
+    parent_key: int | None
+    pending_by_region: dict[int, _PendingInvalidation] = field(default_factory=dict)
+
+
+def new_cache_version() -> str:
+    """
+    キャッシュバージョン用の一意なトークンを生成する。
+
+    Returns:
+        新しいバージョン文字列
+    """
+    return uuid4().hex
+
+
+def schedule_cache_key_deletes(
+    session: Session,
+    region: _CacheRegionLike,
+    *keys: str,
+) -> None:
+    """
+    commit 完了後に実行するキャッシュキー削除を予約する。
+
+    Args:
+        session: 対象セッション
+        region: 削除対象のキャッシュリージョン
+        keys: 削除対象のキャッシュキー一覧
+    """
+    pending = _get_pending_invalidation(session, region)
+    pending.keys.update(keys)
+
+
+def schedule_cache_version_bumps(
+    session: Session,
+    region: _CacheRegionLike,
+    *version_keys: str,
+) -> None:
+    """
+    commit 完了後に実行するキャッシュバージョン更新を予約する。
+
+    Args:
+        session: 対象セッション
+        region: 更新対象のキャッシュリージョン
+        version_keys: 更新対象のバージョン管理キー一覧
+    """
+    pending = _get_pending_invalidation(session, region)
+    pending.version_keys.update(version_keys)
+
+
+def has_pending_cache_invalidation(
+    session: Session | None,
+    region: object | None = None,
+) -> bool:
+    """
+    セッションに保留中のキャッシュ無効化があるか判定する。
+
+    Args:
+        session: 判定対象のセッション
+        region: 判定対象のキャッシュリージョン。省略時は任意リージョンを対象とする
+
+    Returns:
+        保留中の無効化があれば True
+    """
+    if session is None:
+        return False
+
+    pending_by_transaction = _get_pending_invalidations(session)
+    if region is None:
+        return any(
+            pending.keys or pending.version_keys
+            for transaction_pending in pending_by_transaction.values()
+            for pending in transaction_pending.pending_by_region.values()
+        )
+
+    region_key = id(region)
+    return any(
+        region_key in transaction_pending.pending_by_region
+        and bool(
+            transaction_pending.pending_by_region[region_key].keys
+            or transaction_pending.pending_by_region[region_key].version_keys
+        )
+        for transaction_pending in pending_by_transaction.values()
+    )
+
+
+def install_session_cache_invalidation_listeners() -> None:
+    """
+    Session の commit / rollback に連動するキャッシュ無効化リスナーを登録する。
+    """
+    global _LISTENERS_INSTALLED
+    with _LISTENERS_LOCK:
+        if _LISTENERS_INSTALLED:
+            return
+
+        event.listen(Session, "after_commit", _after_commit)
+        event.listen(Session, "after_soft_rollback", _after_soft_rollback)
+        _LISTENERS_INSTALLED = True
+
+
+def _after_commit(session: Session) -> None:
+    """
+    commit 完了後に予約済みのキャッシュ無効化を実行する。
+
+    Args:
+        session: commit 済みセッション
+    """
+    pending_by_transaction = _pop_pending_invalidations(session)
+    pending_by_region = _merge_pending_invalidations(pending_by_transaction)
+    for pending in pending_by_region.values():
+        region = pending.region
+        for key in pending.keys:
+            region.delete(key)
+        for version_key in pending.version_keys:
+            region.set(version_key, new_cache_version())
+
+
+def _after_soft_rollback(session: Session, previous_transaction: object) -> None:
+    """
+    rollback 後に予約済みのキャッシュ無効化を破棄する。
+
+    Args:
+        session: rollback 済みセッション
+        previous_transaction: rollback 対象のトランザクション
+    """
+    _discard_pending_invalidations(session, previous_transaction)
+
+
+def _get_pending_invalidations(session: Session) -> dict[int, _PendingTransactionInvalidation]:
+    """
+    セッションに紐づく保留中キャッシュ無効化一覧を取得する。
+
+    Args:
+        session: 対象セッション
+
+    Returns:
+        トランザクションごとの保留中無効化情報
+    """
+    pending = session.info.setdefault(_PENDING_INVALIDATIONS_SESSION_KEY, {})
+    return pending
+
+
+def _get_pending_invalidation(
+    session: Session,
+    region: _CacheRegionLike,
+) -> _PendingInvalidation:
+    """
+    指定リージョン向けの保留中キャッシュ無効化情報を取得する。
+
+    Args:
+        session: 対象セッション
+        region: 対象キャッシュリージョン
+
+    Returns:
+        対象リージョン向けの保留中無効化情報
+
+    Raises:
+        RuntimeError: 保留中無効化を紐づけるトランザクションが見つからない
+    """
+    current_transaction = _get_current_transaction(session)
+    if current_transaction is None:
+        raise RuntimeError("cache invalidation must be scheduled within an active transaction")
+
+    pending_by_transaction = _get_pending_invalidations(session)
+    transaction_key = id(current_transaction)
+    parent = getattr(current_transaction, "parent", None)
+    pending_by_region = pending_by_transaction.setdefault(
+        transaction_key,
+        _PendingTransactionInvalidation(parent_key=id(parent) if parent is not None else None),
+    ).pending_by_region
+    region_key = id(region)
+    if region_key not in pending_by_region:
+        pending_by_region[region_key] = _PendingInvalidation(region=region)
+    return pending_by_region[region_key]
+
+
+def _pop_pending_invalidations(session: Session) -> dict[int, _PendingTransactionInvalidation]:
+    """
+    セッションに紐づく保留中キャッシュ無効化一覧を取り出して削除する。
+
+    Args:
+        session: 対象セッション
+
+    Returns:
+        取り出した保留中無効化情報
+    """
+    pending = session.info.pop(_PENDING_INVALIDATIONS_SESSION_KEY, {})
+    return pending
+
+
+def _discard_pending_invalidations(session: Session, transaction: object) -> None:
+    """
+    指定トランザクション配下に紐づく保留中無効化だけを破棄する。
+
+    Args:
+        session: 対象セッション
+        transaction: 破棄対象のトランザクション
+    """
+    pending_by_transaction = _get_pending_invalidations(session)
+    target_keys = [id(transaction)]
+    while target_keys:
+        target_key = target_keys.pop()
+        pending_by_transaction.pop(target_key, None)
+        target_keys.extend(
+            transaction_key
+            for transaction_key, pending in tuple(pending_by_transaction.items())
+            if pending.parent_key == target_key
+        )
+
+    if not pending_by_transaction:
+        session.info.pop(_PENDING_INVALIDATIONS_SESSION_KEY, None)
+
+
+def _merge_pending_invalidations(
+    pending_by_transaction: dict[int, _PendingTransactionInvalidation],
+) -> dict[int, _PendingInvalidation]:
+    """
+    トランザクション単位の保留中無効化をリージョン単位へ集約する。
+
+    Args:
+        pending_by_transaction: トランザクションごとの保留中無効化情報
+
+    Returns:
+        リージョンごとに集約した保留中無効化情報
+    """
+    pending_by_region: dict[int, _PendingInvalidation] = {}
+    for transaction_pending in pending_by_transaction.values():
+        for region_key, pending in transaction_pending.pending_by_region.items():
+            if region_key not in pending_by_region:
+                pending_by_region[region_key] = _PendingInvalidation(region=pending.region)
+            pending_by_region[region_key].keys.update(pending.keys)
+            pending_by_region[region_key].version_keys.update(pending.version_keys)
+    return pending_by_region
+
+
+def _get_current_transaction(session: Session) -> object | None:
+    """
+    現在の論理トランザクションを返す。
+
+    Args:
+        session: 対象セッション
+
+    Returns:
+        nested transaction があればそれを、なければ root transaction を返す
+    """
+    nested_transaction = session.get_nested_transaction()
+    if nested_transaction is not None:
+        return nested_transaction
+    return session.get_transaction()

--- a/src/repositories/base.py
+++ b/src/repositories/base.py
@@ -1,10 +1,16 @@
-from uuid import uuid4
-
 from dogpile.cache.region import CacheRegion
 from sqlalchemy.orm.session import Session
 
 from ..libs.cache import NullCacheRegion, get_query_cache_region
+from ..libs.cache.invalidation import (
+    install_session_cache_invalidation_listeners,
+    new_cache_version,
+    schedule_cache_key_deletes,
+    schedule_cache_version_bumps,
+)
 from ..libs.page import Page
+
+install_session_cache_invalidation_listeners()
 
 
 class RepositoryError(Exception):
@@ -96,12 +102,11 @@ class BaseRepository:
         Args:
             namespaces: 更新対象の namespace 一覧
         """
-        for namespace in namespaces:
-            # 競合で無効化を取りこぼさないよう、read-modify-write ではなく毎回新しい一意値に差し替える。
-            self.region.set(
-                self._cache_version_key(namespace),
-                self._new_cache_version(),
-            )
+        schedule_cache_version_bumps(
+            self.session,
+            self.region,
+            *(self._cache_version_key(namespace) for namespace in namespaces),
+        )
 
     def _delete_cache_keys(self, *keys: str) -> None:
         """
@@ -110,8 +115,7 @@ class BaseRepository:
         Args:
             keys: 削除対象のキャッシュキー一覧
         """
-        for key in keys:
-            self.region.delete(key)
+        schedule_cache_key_deletes(self.session, self.region, *keys)
 
     @staticmethod
     def _new_cache_version() -> str:
@@ -121,4 +125,4 @@ class BaseRepository:
         Returns:
             新しいバージョン文字列
         """
-        return uuid4().hex
+        return new_cache_version()

--- a/tests/unit/test_repository_query_cache.py
+++ b/tests/unit/test_repository_query_cache.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator
 from threading import Barrier, Lock, Thread
+from time import sleep
 
 import pytest
 from dogpile.cache.api import NO_VALUE
@@ -12,6 +13,7 @@ from src.dao.models.tag import TagDao
 from src.dao.models.user import UserDao
 from src.entities.bookmark import BookmarkEntity
 from src.entities.user import UserEntity
+from src.libs.cache import invalidation as cache_invalidation
 from src.libs.enum import AuthorityEnum
 from src.libs.page import Page
 from src.libs.util import get_hashed_id
@@ -90,6 +92,7 @@ def test_user_repository_find_one_cache_and_invalidation(
     first.name = "alice-renamed"
     first.disabled = True
     repository.update_one(first, current_name="alice")
+    session.commit()
 
     # 更新後は古い詳細キャッシュが無効化され、再度 DB を読む。
     refreshed = repository.find_one(name="alice-renamed")
@@ -171,6 +174,7 @@ def test_user_repository_find_all_cache_is_invalidated_on_add(
             authority=AuthorityEnum.READWRITE,
         )
     )
+    session.commit()
 
     # add 後は一覧 version が進み、一覧クエリが再評価される。
     refreshed = repository.find_all()
@@ -291,6 +295,7 @@ def test_user_repository_find_all_cache_invalidation_reaches_all_pages(
             authority=AuthorityEnum.READWRITE,
         )
     )
+    session.commit()
 
     refreshed_first_page = first_page_repository.find_all()
     cached_first_page = first_page_repository.find_all()
@@ -350,6 +355,7 @@ def test_bookmark_repository_find_one_cache_and_invalidation(
     first.memo = "after"
     first.tags = ["tag2"]
     repository.update_one(first, current_hashed_id=bookmark.hashed_id)
+    session.commit()
 
     # 更新後は詳細キャッシュが無効化され、タグも含めて再取得される。
     refreshed = repository.find_one(hashed_id=bookmark.hashed_id)
@@ -450,6 +456,7 @@ def test_bookmark_repository_delete_one_invalidates_detail_and_lists(
     assert tag_list_calls == 1
 
     repository.delete_one(hashed_id=bookmark.hashed_id)
+    session.commit()
 
     # delete 実行時に対象 bookmark を解決するため、詳細 DAO は 1 回追加で呼ばれる。
     assert detail_calls == 2
@@ -513,6 +520,7 @@ def test_bookmark_repository_tag_list_cache_normalizes_key_and_invalidates_on_ad
             tags=["tag1", "tag2"],
         )
     )
+    session.commit()
 
     # add 後は tag-list version が進み、同じタグ条件でも再検索される。
     refreshed = repository.find_by_tags(["tag1", "tag2"])
@@ -712,6 +720,7 @@ def test_bookmark_repository_tag_list_cache_invalidation_reaches_all_pages(
             tags=["tag1"],
         )
     )
+    session.commit()
 
     refreshed_small_page = small_page_repository.find_by_tags(["tag1"])
     cached_small_page = small_page_repository.find_by_tags(["tag1"])
@@ -741,14 +750,171 @@ def test_bump_cache_versions_does_not_depend_on_current_version(
 
     monkeypatch.setattr(repository, "_get_cache_version", fail_get_version)
 
-    repository._bump_cache_versions("list")
+    with session.begin():
+        repository._bump_cache_versions("list")
     first_version = repository.region.get(repository._cache_version_key("list"))
-    repository._bump_cache_versions("list")
+    with session.begin():
+        repository._bump_cache_versions("list")
     second_version = repository.region.get(repository._cache_version_key("list"))
 
     assert isinstance(first_version, str)
     assert isinstance(second_version, str)
     assert first_version != second_version
+
+
+def test_detail_cache_is_deleted_after_commit_but_same_transaction_reads_bypass_cache(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    詳細キャッシュ削除は commit 後に遅延し、同一トランザクション中の再読込は cache を bypass する
+    """
+    UnitDataFactory(session).create_user("alice")
+    repository = UserRepository(session, region=memory_region)
+
+    calls = 0
+    original = repository.user_operator.find_one_by_name
+
+    def wrapped(name: str) -> UserDao | None:
+        # commit 前後の再読込が DB を見に行く回数を追跡する。
+        nonlocal calls
+        calls += 1
+        return original(name)
+
+    monkeypatch.setattr(repository.user_operator, "find_one_by_name", wrapped)
+
+    cached = repository.find_one(name="alice")
+    assert cached.name == "alice"
+    assert calls == 1
+    assert memory_region.get(repository._find_one_cache_key("alice")).name == "alice"
+
+    cached.name = "alice-renamed"
+    repository.update_one(cached, current_name="alice")
+
+    # commit 前は既存キャッシュをまだ削除せず、同一 transaction の読込だけ cache bypass する。
+    pending = repository.find_one(name="alice-renamed")
+    assert pending.name == "alice-renamed"
+    assert calls == 3
+    assert memory_region.get(repository._find_one_cache_key("alice")).name == "alice"
+    assert memory_region.get(repository._find_one_cache_key("alice-renamed")) is NO_VALUE
+
+    session.commit()
+
+    refreshed = repository.find_one(name="alice-renamed")
+    assert refreshed.name == "alice-renamed"
+    assert calls == 4
+    assert memory_region.get(repository._find_one_cache_key("alice")) is NO_VALUE
+    assert (
+        memory_region.get(repository._find_one_cache_key("alice-renamed")).name == "alice-renamed"
+    )
+
+
+def test_list_cache_invalidation_is_discarded_on_rollback(
+    session: Session,
+    memory_region: CacheRegion,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    rollback 時は予約済み一覧キャッシュ無効化が破棄される
+    """
+    UnitDataFactory(session).create_user("alice")
+    repository = UserRepository(
+        session,
+        page=Page(number=1, size=10),
+        region=memory_region,
+    )
+
+    calls = 0
+    original = repository.user_operator.find_all
+
+    def wrapped() -> list[UserDao]:
+        # rollback 後に既存一覧キャッシュへ戻れるかを DB 呼び出し回数で確認する。
+        nonlocal calls
+        calls += 1
+        return original()
+
+    monkeypatch.setattr(repository.user_operator, "find_all", wrapped)
+
+    first = repository.find_all()
+    assert [user.name for user in first] == ["alice"]
+    assert calls == 1
+    version_key = repository._cache_version_key("list")
+    cached_version = memory_region.get(version_key)
+
+    repository.add_one(
+        UserEntity(
+            name="bob",
+            hashed_password="hashed-password",
+            disabled=False,
+            authority=AuthorityEnum.READWRITE,
+        )
+    )
+    session.rollback()
+
+    rolled_back = repository.find_all()
+    assert [user.name for user in rolled_back] == ["alice"]
+    assert calls == 1
+    assert memory_region.get(version_key) == cached_version
+
+
+def test_nested_rollback_keeps_outer_transaction_cache_invalidation(
+    session: Session,
+    memory_region: CacheRegion,
+) -> None:
+    """
+    正常系:
+    nested transaction の rollback では outer transaction の無効化予約は失われない
+    """
+    memory_region.set("user:detail:outer", {"value": "cached"})
+    memory_region.set("user:detail:nested", {"value": "cached"})
+
+    with session.begin():
+        cache_invalidation.schedule_cache_key_deletes(session, memory_region, "user:detail:outer")
+        nested_transaction = session.begin_nested()
+        cache_invalidation.schedule_cache_key_deletes(session, memory_region, "user:detail:nested")
+        nested_transaction.rollback()
+
+    assert memory_region.get("user:detail:outer") is NO_VALUE
+    assert memory_region.get("user:detail:nested") == {"value": "cached"}
+
+
+def test_install_session_cache_invalidation_listeners_is_thread_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    正常系:
+    listener 登録は並行実行されても 1 回だけ行われる
+    """
+    call_count = 0
+    call_lock = Lock()
+    barrier = Barrier(5)
+
+    def fake_listen(target: object, identifier: str, fn: object) -> None:
+        del target, identifier, fn
+        sleep(0.01)
+
+        nonlocal call_count
+        with call_lock:
+            call_count += 1
+
+    monkeypatch.setattr(cache_invalidation.event, "listen", fake_listen)
+    monkeypatch.setattr(cache_invalidation, "_LISTENERS_INSTALLED", False)
+
+    def worker() -> None:
+        barrier.wait()
+        cache_invalidation.install_session_cache_invalidation_listeners()
+
+    threads = [Thread(target=worker) for _ in range(5)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    # after_commit / after_soft_rollback の 2 登録だけに収まることを確認する。
+    assert call_count == 2
 
 
 def test_get_cache_version_initialization_is_atomic(session: Session) -> None:


### PR DESCRIPTION
## 概要
- repository の書き込み系キャッシュ無効化を commit 後実行へ変更
- Session event を使った共通の無効化予約ロジックを追加
- 同一 transaction 中の stale cache 再利用を避けるため query cache を調整
- nested transaction rollback と listener 多重登録の考慮を追加
- 設計書と単体テストを更新

## 変更内容
- `src/libs/cache/invalidation.py` を追加し、cache key 削除/version bump の予約と `after_commit` / `after_soft_rollback` の処理を実装
- `src/repositories/base.py` の無効化処理を即時実行から予約方式へ変更
- `src/libs/cache/decorator.py` で pending invalidation 中は cache bypass するよう変更
- `tests/unit/test_repository_query_cache.py` に commit 後反映、rollback 破棄、nested rollback、listener 登録排他のテストを追加
- `docs/query_cache_design.md` を現状実装に合わせて更新
